### PR TITLE
Make docker environment for web UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ collections
 etc/readers.tsv
 lib/tika-server.jar
 lib/tika-server.jar.md5
-Library
 library.db
 log
 queue

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Contributing
+
+The Distant Reader consists of two general parts: a text processing workflow designed to run on HPC clusters, and a web-based user interface.
+The parts communicate through a shared-file space containing _study carrels_.
+A study carrel collects a specific pile of documents with its analysis, and
+each study carrel takes the form of a directory.
+
+## Web Interface
+
+You can run the web interface locally with Docker.
+(However, note that Docker isn't used for the production deploy).
+
+    make web-run
+    
+And then you can view the website at http://localhost:8000

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+
+.PHONY: docker web-run
+
+docker: config/Dockerfile-web config/httpd.conf
+	docker build --file config/Dockerfile-web  --tag reader-web .
+
+web-run: docker
+	docker run -d -p 8000:80 -p 8001:8080 reader-web

--- a/config/Dockerfile-web
+++ b/config/Dockerfile-web
@@ -1,0 +1,21 @@
+# The intention of this file is to set up a local test
+# envrionment of the web front-end to Distant Reader.
+
+FROM centos:7
+
+RUN yum install -y httpd
+
+RUN mkdir -p /var/log/httpd && chmod a+rwx /var/log/httpd
+
+COPY config /etc/httpd/conf/
+
+RUN mkdir -p /data-disk/www/html/library /data-disk/www/html/reader /data-disk/www/html/cord /data-disk/www/html/localhost  
+
+COPY www/library /data-disk/www/html/library
+COPY www/reader /data-disk/www/html/reader
+
+EXPOSE 80 8080
+
+CMD httpd -DFOREGROUND
+
+# vim:ft=Dockerfile

--- a/config/httpd.conf
+++ b/config/httpd.conf
@@ -40,7 +40,7 @@ ServerRoot "/etc/httpd"
 #
 #Listen 12.34.56.78:80
 Listen 80
-Listen localhost:8080
+#Listen localhost:8080
 
 #
 # Dynamic Shared Object (DSO) Support


### PR DESCRIPTION
This will make it easier for people to run and test the web UI component
without needing access to the production server. Using docker gives us a
way to test Apache configuration changes and will allow for us to
migrate the web to new technologies.

It doesn't handle the password access yet.