### PR TITLE
Flask add routes

### DIFF
--- a/config/Dockerfile-web
+++ b/config/Dockerfile-web
@@ -21,6 +21,8 @@ RUN mkdir -p /var/log/httpd \
         /data-disk/www/html/reader \
         /data-disk/www/html/cord \
         /data-disk/www/html/localhost \
+        /data-disk/reader-compute/reader-classic/queue/todo/ \
+        /data-disk/reader-compute/reader-classic/queue/backlog/ \
         /opt/reader \
         /opt/reader/log \
         /opt/reader/pip_cache \

--- a/config/Dockerfile-web
+++ b/config/Dockerfile-web
@@ -24,9 +24,10 @@ RUN mkdir -p /var/log/httpd \
         /data-disk/reader-compute/reader-classic/queue/todo/ \
         /data-disk/reader-compute/reader-classic/queue/backlog/ \
         /opt/reader \
+        /opt/reader/env \
         /opt/reader/log \
         /opt/reader/pip_cache \
-    && chmod a+rwx /var/log/httpd /opt/reader/ /opt/reader/log /opt/reader/pip_cache \
+    && chmod -R a+rwx /var/log/httpd /opt/reader/ /opt/reader/log /opt/reader/pip_cache \
     && ln -s /usr/bin/perl /data-disk/bin/perl
 
 # dummy user "test", password "test"
@@ -46,6 +47,9 @@ USER app
 
 # set up the python source
 COPY webui /opt/reader
+COPY config/webui-config.docker /opt/reader/config.docker
+RUN echo '/opt/reader/config.docker' > /opt/reader/env/READER_CONFIG
+
 ENV PIPENV_CACHE_DIR=/opt/reader/pip_cache
 ENV WORKON_HOME=/opt/reader/pip_cache
 RUN cd /opt/reader && pipenv install --deploy

--- a/config/httpd-le-ssl.conf
+++ b/config/httpd-le-ssl.conf
@@ -99,3 +99,4 @@ Include /etc/letsencrypt/options-ssl-apache.conf
 SSLCertificateChainFile /etc/letsencrypt/live/distantreader.org/chain.pem
 </VirtualHost>
 </IfModule>
+# vim:ft=apache

--- a/config/httpd.conf
+++ b/config/httpd.conf
@@ -377,6 +377,11 @@ HostnameLookups on
 	ErrorDocument 401 /etc/401.html
 
 	<Location "/p">
+		AuthType Basic
+		AuthName "Authentication Required"
+		AuthUserFile "/data-disk/etc/reader-htpasswd"
+		Require valid-user
+
 		ProxyPass "http://localhost:8000"
 		ProxyPassReverse "http://localhost:8000"
 	</Location>

--- a/config/runit/reader/run
+++ b/config/runit/reader/run
@@ -4,4 +4,4 @@ export PIPENV_CACHE_DIR=/opt/reader/pip_cache
 export WORKON_HOME=/opt/reader/pip_cache
 exec 2>&1
 cd /opt/reader
-exec chpst -u app pipenv run gunicorn --access-logfile - hello:app
+exec chpst -u app -e /opt/reader/env pipenv run gunicorn --access-logfile - hello:app

--- a/config/webui-config.docker
+++ b/config/webui-config.docker
@@ -1,0 +1,7 @@
+# configure for local laptop
+APPLICATION_ROOT='/p/'
+
+TODO_PATH = '/data-disk/reader-compute/reader-classic/queue/todo'
+BACKLOG_PATH = '/data-disk/reader-compute/reader-classic/queue/backlog'
+SOLR_URL = 'http://localhost:7000/solr/reader-gutenberg'
+

--- a/deploy/deploy-web.sh
+++ b/deploy/deploy-web.sh
@@ -9,7 +9,7 @@
 APACHE_CONFIG_FILES=config/httpd.conf \
     config/httpd-le-ssl.conf
 for f in $APACHE_CONFIG_FILES; do
-    install -m 666 $f /etc/httpd/conf/
+    install -m 666 $f "/etc/httpd/conf/$(basename $f)"
 done
 
 # copy all the static files and cgi scripts

--- a/webui/Pipfile
+++ b/webui/Pipfile
@@ -6,6 +6,7 @@ name = "pypi"
 [packages]
 flask = "*"
 gunicorn = "*"
+pysolr = "*"
 
 [dev-packages]
 

--- a/webui/Pipfile.lock
+++ b/webui/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "81cb5d5f0b11719d8d9c5ec9cc683fdcf959c652fda256d5552a82d0f459a99c"
+            "sha256": "c1632049d618de85a4e672c10a59e54469871a5544b45303b70dbea777bfa352"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,6 +16,21 @@
         ]
     },
     "default": {
+        "certifi": {
+            "hashes": [
+                "sha256:1a4995114262bffbc2413b159f2a1a480c969de6e6eb13ee966d470af86af59c",
+                "sha256:719a74fb9e33b9bd44cc7f3a8d94bc35e4049deebe19ba7d8e108280cfd59830"
+            ],
+            "version": "==2020.12.5"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa",
+                "sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==4.0.0"
+        },
         "click": {
             "hashes": [
                 "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a",
@@ -39,6 +54,14 @@
             ],
             "index": "pypi",
             "version": "==20.0.4"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
+                "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.10"
         },
         "itsdangerous": {
             "hashes": [
@@ -113,6 +136,29 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.1.1"
+        },
+        "pysolr": {
+            "hashes": [
+                "sha256:6ef05feb87c614894243eddc62e9b0a6134a889c159ae868655cf6cd749545e6"
+            ],
+            "index": "pypi",
+            "version": "==3.9.0"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804",
+                "sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==2.25.1"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:1b465e494e3e0d8939b50680403e3aedaa2bc434b7d5af64dfd3c958d7f5ae80",
+                "sha256:de3eedaad74a2683334e282005cd8d7f22f4d55fa690a2a1020a416cb0a47e73"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "version": "==1.26.3"
         },
         "werkzeug": {
             "hashes": [

--- a/webui/config.local
+++ b/webui/config.local
@@ -1,0 +1,10 @@
+# configure for local laptop
+
+SECRET_KEY='replace in production'
+TESTING=True  # false in production
+APPLICATION_ROOT='/'   # or '/p/'?
+
+TODO_PATH = '/data-disk/reader-compute/reader-classic/queue/todo'
+BACKLOG_PATH = '/data-disk/reader-compute/reader-classic/queue/backlog'
+SOLR_URL = 'http://localhost:7000/solr/reader-gutenberg'
+

--- a/webui/hello.py
+++ b/webui/hello.py
@@ -1,6 +1,258 @@
-from flask import Flask
+from flask import (Flask,render_template, request)
+from werkzeug.utils import secure_filename
+from datetime import datetime
+import os.path
+import pysolr
+
 app = Flask(__name__)
+
+# configure
+TODO_PATH = '/data-disk/reader-compute/reader-classic/queue/todo'
+BACKLOG_PATH = '/data-disk/reader-compute/reader-classic/queue/backlog'
+SOLR_URL = 'http://10.0.1.11:8983/solr/reader-gutenberg'
+
+NUMERALS = {1:'I', 2:'II', 3:'III', 4:'IV', 5:'V',
+        6:'VI', 7:'VII', 8:'VIII', 9:'IX', 10:'X',
+        11:'XI', 12:'XII', 13:'XIII', 14:'XIV', 15:'XV',
+        16:'XVI', 17:'XVII', 18:'XVIII', 19:'XIX', 20:'XX'}
+
+@app.template_filter('roman_numeral')
+def roman_numeral(n):
+    return NUMERALS.get(n, '')
+
 
 @app.route('/')
 def hello_world():
-    return 'Hello, World!'
+    return render_template('home.html')
+
+@app.route('/create/url2carrel')
+def url2carrel():
+    TYPE = 'url2carrel'
+    shortname = request.args.get('shortname', '')
+    target_url = request.args.get('url', '')
+    confirm = request.args.get('confirm', '')
+    queue = request.args.get('queue', '')
+    # my $username  = $cgi->remote_user();
+    username = 'nobody'
+
+    if shortname == '' or target_url == '':
+        return render_template('url2carrel.html')
+    if queue != '':
+        now = datetime.now().strftime("%Y-%m-%d\t%H:%M")
+        # this is a security hole since shortname is user supplied
+        with open(os.path.join(TODO_PATH, shortname + ".tsv"), mode="w") as f:
+            f.write("\t".join([TYPE, shortname, now, username, target_url]))
+            f.write("\n")
+        return render_template('url2carrel.html')
+
+@app.route('/create/urls2carrel', methods=['GET', 'POST'])
+def urls2carrel():
+    TYPE    = 'urls2carrel'
+    POSTMAX = 1024 * 1000
+
+    # initialize
+    #$CGI::POST_MAX = POSTMAX;
+    shortname  = request.args.get('shortname', '')
+    queue = request.args.get('queue', '')
+    #my $username   = $cgi->remote_user();
+    username = 'nobody'
+
+    if shortname == '':
+        return render_template('urls2carrel.html')
+    if queue != '':
+        # get the basename of the loaded file, and move it to the backlog
+        f = request.files['urls']
+        f.save(os.path.join(BACKLOG_PATH, secure_filename(f.filename)))
+
+        # update the queue
+        now = datetime.now().strftime("%Y-%m-%d\t%H:%M")
+        # this is a security hole since shortname is user supplied
+        with open(os.path.join(TODO_PATH, shortname + ".tsv"), mode="w") as f:
+            f.write("\t".join([TYPE, shortname, now, username, name + ".txt"]))
+            f.write("\n")
+        return render_template('urls2carrel-queue.html', username=username, shortname=shortname)
+
+
+@app.route('/create/zip2carrel', methods=['GET', 'POST'])
+def zip2carrel():
+# configure
+    TYPE = 'zip2carrel'
+    POSTMAX = 1024 * 50000
+
+    # initialize
+    # $CGI::POST_MAX = POSTMAX;
+    shortname = request.form.get('shortname', '')
+    queue = request.form.get('queue', '')
+    #my $username   = $cgi->remote_user();
+    username = 'nobody'
+
+    if shortname == '':
+        return render_template('zip2carrel.html')
+    if queue != '':
+        # get the basename of the loaded file, and move it to the backlog
+        f = request.files['zip']
+        name = secure_filename(f.filename)
+        f.save(os.path.join(BACKLOG_PATH, name))
+
+        # update the queue
+        now = datetime.now().strftime("%Y-%m-%d\t%H:%M")
+        # this is a security hole since shortname is user supplied
+        with open(os.path.join(TODO_PATH, shortname + ".tsv"), mode="w") as f:
+            f.write("\t".join([TYPE, shortname, now, username, name]))
+            f.write("\n")
+        return render_template('zip2carrel-queue.html', username=username, shortname=shortname)
+
+@app.route('/create/file2carrel', methods=['GET', 'POST'])
+def file2carrel():
+# configure
+    TYPE = 'file2carrel'
+    POSTMAX = 1024 * 20000
+
+    shortname = request.form.get('shortname', '')
+    queue = request.form.get('queue', '')
+    # username   = $cgi->remote_user();
+    username = 'nobody'
+
+    if shortname == '':
+        return render_template('file2carrel.html')
+    if queue != '':
+        # get the basename of the loaded file, and move it to the backlog
+        f = request.files['file']
+        name = secure_filename(f.filename)
+        f.save(os.path.join(BACKLOG_PATH, name))
+
+        # update the queue
+        now = datetime.now().strftime("%Y-%m-%d\t%H:%M")
+        # this is a security hole since shortname is user supplied
+        with open(os.path.join(TODO_PATH, shortname + ".tsv"), mode="w") as f:
+            f.write("\t".join([TYPE, shortname, now, username, name]))
+            f.write("\n")
+        return render_template('file2carrel-queue.html', username=username, shortname=shortname)
+
+@app.route('/create/trust2carrel', methods=['GET', 'POST'])
+def trust2carrel():
+    # configure
+    TYPE = 'trust'
+    POSTMAX = 1024 * 5000
+
+    # initialize
+    shortname = request.form.get('shortname', '')
+    queue = request.form.get('queue', '')
+    # username   = $cgi->remote_user();
+    username = 'nobody'
+
+    if shortname == '':
+        return render_template('trust2carrel.html')
+    if queue != '':
+        # get the basename of the loaded file, and move it to the backlog
+        f = request.files['tsv']
+        name = secure_filename(f.filename)
+        f.save(os.path.join(BACKLOG_PATH, name))
+
+        now = datetime.now().strftime("%Y-%m-%d\t%H:%M")
+        # this is a security hole since shortname is user supplied
+        with open(os.path.join(TODO_PATH, shortname + ".tsv"), mode="w") as f:
+            f.write("\t".join([TYPE, shortname, now, username, name]))
+            f.write("\n")
+        return render_template('trust2carrel-queue.html', username=username, shortname=shortname)
+
+@app.route('/create/biorxiv2carrel', methods=['GET', 'POST'])
+def biorxiv2carrel():
+    # configure
+    TYPE = 'biorxiv'
+    POSTMAX = 1024 * 5000
+
+    shortname = request.form.get('shortname', '')
+    queue = request.form.get('queue', '')
+    # username   = $cgi->remote_user();
+    username = 'nobody'
+
+    if shortname == '':
+        return render_template('biorxiv2carrel.html')
+    if queue != '':
+        # get the basename of the loaded file, and move it to the backlog
+        f = request.files['xml']
+        name = secure_filename(f.filename)
+        f.save(os.path.join(BACKLOG_PATH, name))
+
+        now = datetime.now().strftime("%Y-%m-%d\t%H:%M")
+        # this is a security hole since shortname is user supplied
+        with open(os.path.join(TODO_PATH, shortname + ".tsv"), mode="w") as f:
+            f.write("\t".join([TYPE, shortname, now, username, name]))
+            f.write("\n")
+        return render_template('biorxiv2carrel-queue.html', username=username, shortname=shortname)
+
+# array_to_dict takes a list like ['aaa', 123, 'bbb', 234, 'ccc', 345, ...]
+# interprets it as a list of key-value pairs, and returns
+# a dictionary made from those key-values e.g. {'aaa': 123, 'bbb': 234, 'ccc': 345, ...}
+def array_to_dict(a):
+    i = iter(a)
+    return dict(zip(i, i))
+
+
+@app.route('/gutenberg')
+def gutenberg():
+    # configure
+    FACETFIELD = ['facet_subject', 'facet_author', 'facet_classification']
+    ROWS = 499
+    # SEARCH2QUEUE = './search2queue.cgi?query='
+
+    # initialize
+    query = request.args.get('query', '')
+    solr = pysolr.Solr(url=SOLR_URL)
+    #my %numerals = NUMERALS;
+
+    if query == '':
+        return render_template('gutenberg.html', query='', results=[])
+
+    # build the search options
+    search_options = {
+            'facet.field': FACETFIELD,
+            'facet': 'true',
+            'rows': ROWS
+    }
+
+    response = solr.search(query, **search_options)
+
+    classification_facets = array_to_dict(response.facets['facet_fields']['facet_classification'])
+    author_facets = array_to_dict(response.facets['facet_fields']['facet_author'])
+    subject_facets = array_to_dict(response.facets['facet_fields']['facet_subject'])
+
+    total_hits = response.hits
+    num_displayed = len(response)
+
+    # sort the subject and classification field for these results
+    for doc in response.docs:
+        doc.get('classification', []).sort()
+        doc.get('subject', []).sort()
+
+    return render_template('gutenberg-results.html',
+            query=query,
+            total_hits=total_hits,
+            num_displayed=num_displayed,
+            results=response.docs,
+            author_facets=author_facets,
+            subject_facets=subject_facets,
+            classification_facets=classification_facets)
+
+@app.route('/create/gutenberg')
+def create_gutenberg():
+    TYPE = 'gutenberg'
+
+    # initialize
+    shortname = request.args.get('shortname', '')
+    query = request.args.get('query', '')
+    queue = request.args.get('queue', '')
+    # my $username  = $cgi->remote_user();
+    username = 'nobody'
+
+    if shortname == '':
+        return render_template('gutenberg-create.html', query=query)
+    if queue != '':
+        now = datetime.now().strftime("%Y-%m-%d\t%H:%M")
+        # this is a security hole since shortname is user supplied
+        with open(os.path.join(TODO_PATH, shortname + ".tsv"), mode="w") as f:
+            f.write("\t".join([TYPE, shortname, now, username, query]))
+            f.write("\n")
+        return render_template('gutenberg-queue.html', username=username, shortname=shortname)
+

--- a/webui/templates/biorxiv2carrel-queue.html
+++ b/webui/templates/biorxiv2carrel-queue.html
@@ -1,0 +1,46 @@
+<html>
+<head>
+	<title>The Distant Reader - Biorxiv citation (XML) file to study carrel</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<link rel="stylesheet" href="/etc/style.css">
+	<style>
+		.item { margin-bottom: 1em }
+	</style>
+</head>
+<body>
+<div class="header">
+	<h1>The Distant Reader - Biorxiv citation (XML) file to study carrel</h1>
+</div>
+
+<div class="col-3 col-m-3 menu">
+  <ul>
+		<li style='margin-bottom: 2em'><a href="/">Distant Reader home</a></li>
+		
+		<li ><a href="/file2carrel/">File to study carrel</a></li>
+		<li><a href="/zip2carrel/">Zip to study carrel</a></li>
+		<li><a href="/url2carrel/">URL to study carrel</a></li>
+		<li><a href="/urls2carrel/">URLs to study carrel</a></li>
+		<li><a href="/trust2carrel/">HathiTrust to study carrel</a></li>
+		<li style='margin-bottom: 2em'>Biorxiv to study carrel</li>
+		
+		<li><a href="/gutenberg/">Gutenberg to study carrel</a></li>
+		<li><a href="/cord/">COVID-19 to study carrel</a></li>
+		
+ </ul>
+</div>
+
+<div class="col-9 col-m-9">
+
+	<p><strong>{{ username }}</strong>, your carrel has been queued for creation. Thank you for your submission!</p>
+	
+	<div class="footer">
+		<p style='text-align: right'>
+		Eric Lease Morgan<br />
+		November 28, 2020
+		</p>
+	</div>
+
+</div>
+
+</body>
+</html>

--- a/webui/templates/biorxiv2carrel.html
+++ b/webui/templates/biorxiv2carrel.html
@@ -1,0 +1,67 @@
+<html>
+<head>
+	<title>The Distant Reader - Biorxiv citation (XML) file to study carrel</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<link rel="stylesheet" href="/etc/style.css">
+	<style>
+		.item { margin-bottom: 1em }
+	</style>
+</head>
+<body>
+<div class="header">
+	<h1>The Distant Reader - Biorxiv citation (XML) file to study carrel</h1>
+</div>
+
+<div class="col-3 col-m-3 menu">
+  <ul>
+		<li style='margin-bottom: 2em'><a href="/">Distant Reader home</a></li>
+		
+		<li ><a href="/file2carrel/">File to study carrel</a></li>
+		<li><a href="/zip2carrel/">Zip to study carrel</a></li>
+		<li><a href="/url2carrel/">URL to study carrel</a></li>
+		<li><a href="/urls2carrel/">URLs to study carrel</a></li>
+		<li><a href="/trust2carrel/">HathiTrust to study carrel</a></li>
+		<li style='margin-bottom: 2em'>Biorxiv to study carrel</li>
+		
+		<li><a href="/gutenberg/">Gutenberg to study carrel</a></li>
+		<li><a href="/cord/">COVID-19 to study carrel</a></li>
+		
+ </ul>
+</div>
+
+<div class="col-9 col-m-9">
+
+	<p>Use this form to queue a Biorxiv citation (XML) file to be processed by the Distant Reader.</p>
+	
+	<form action="./" method="post" enctype="multipart/form-data">
+	<table>
+		<tr>
+			<td style='text-align:right'>One-word name describing your carrel:</td>
+			<td><input type='text'
+			           name='shortname'
+			           autofocus="autofocus"
+			           onkeyup="this.value = this.value.replace( /[^a-z|^A-Z|0-9|_|\-]/, '' )" />
+			</td>
+		</tr>
+		<tr>
+			<td style='text-align:right'>Biorxiv XML file:</td>
+			<td><input type="file" name="xml" accept=".xml" /></td>
+		</tr>
+			<td style='text-align:right'>Action</td>
+			<td><input type='submit' name='queue' value='Queue the file' /></td>
+		<tr>
+	</table>
+	
+	</form>
+
+	<div class="footer">
+		<p style='text-align: right'>
+		Eric Lease Morgan<br />
+		November 28, 2020
+		</p>
+	</div>
+
+</div>
+
+</body>
+</html>

--- a/webui/templates/file2carrel-queue.html
+++ b/webui/templates/file2carrel-queue.html
@@ -1,0 +1,46 @@
+<html>
+<head>
+	<title>File to study carrel</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<link rel="stylesheet" href="/etc/style.css">
+	<style>
+		.item { margin-bottom: 1em }
+	</style>
+</head>
+<body>
+<div class="header">
+	<h1>File to study carrel</h1>
+</div>
+
+<div class="col-3 col-m-3 menu">
+  <ul>
+		<li style='margin-bottom: 2em'><a href="/">Distant Reader home</a></li>
+		
+		<li>File to study carrel</li>
+		<li><a href="/zip2carrel/">Zip to study carrel</a></li>
+		<li><a href="/url2carrel/">URL to study carrel</a></li>
+		<li><a href="/urls2carrel/">URLs to study carrel</a></li>
+		<li><a href="/trust2carrel/">HathiTrust to study carrel</a></li>
+		<li style='margin-bottom: 2em'><a href="/biorxiv2carrel/">Biorxiv to study carrel</a></li>
+		
+		<li><a href="/gutenberg/">Gutenberg to study carrel</a></li>
+		<li><a href="/cord/">COVID-19 to study carrel</a></li>
+		
+ </ul>
+</div>
+
+<div class="col-9 col-m-9">
+
+    <p><strong>{{ username }}</strong>, your carrel <strong>{{ shortname }}</strong> has been queued for creation. Thank you for your submission!</p>
+	
+	<div class="footer">
+		<p style='text-align: right'>
+		Eric Lease Morgan<br />
+		November 29, 2020
+		</p>
+	</div>
+
+</div>
+
+</body>
+</html>

--- a/webui/templates/file2carrel.html
+++ b/webui/templates/file2carrel.html
@@ -1,0 +1,67 @@
+<html>
+<head>
+	<title>The Distant Reader - File to study carrel</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<link rel="stylesheet" href="/etc/style.css">
+	<style>
+		.item { margin-bottom: 1em }
+	</style>
+</head>
+<body>
+<div class="header">
+	<h1>The Distant Reader - File to study carrel</h1>
+</div>
+
+<div class="col-3 col-m-3 menu">
+  <ul>
+		<li style='margin-bottom: 2em'><a href="/">Distant Reader home</a></li>
+		
+		<li>File to study carrel</li>
+		<li><a href="/zip2carrel/">Zip to study carrel</a></li>
+		<li><a href="/url2carrel/">URL to study carrel</a></li>
+		<li><a href="/urls2carrel/">URLs to study carrel</a></li>
+		<li><a href="/trust2carrel/">HathiTrust to study carrel</a></li>
+		<li style='margin-bottom: 2em'><a href="/biorxiv2carrel/">Biorxiv to study carrel</a></li>
+		
+		<li><a href="/gutenberg/">Gutenberg to study carrel</a></li>
+		<li><a href="/cord/">COVID-19 to study carrel</a></li>
+		
+ </ul>
+</div>
+
+<div class="col-9 col-m-9">
+
+	<p>Use this form to submit a file from your computer and have it processed by the Distant Reader.</p>
+	
+	<form action="" method="post" enctype="multipart/form-data">
+	<table>
+		<tr>
+			<td style='text-align:right'>One-word name describing your carrel:</td>
+			<td><input type='text'
+			           name='shortname'
+			           autofocus="autofocus"
+			           onkeyup="this.value = this.value.replace( /[^a-z|^A-Z|0-9|_|\-]/, '' )" />
+			</td>
+		</tr>
+		<tr>
+			<td style='text-align:right'>Plain text (.txt), PDF (.pdf), or a Word Document (.doc or .docx) file:</td>
+			<td><input type="file" name="file" accept=".txt,.pdf,.doc,.docx" /></td>
+		</tr>
+			<td style='text-align:right'>Action</td>
+			<td><input type='submit' name='queue' value='Queue the file' /></td>
+		<tr>
+	</table>
+	
+	</form>
+
+	<div class="footer">
+		<p style='text-align: right'>
+		Eric Lease Morgan &lt;<a href="mailto:emorgan\@nd.edu">emorgan\@nd.edu</a>&gt;<br />
+		November 29, 2020
+		</p>
+	</div>
+
+</div>
+
+</body>
+</html>

--- a/webui/templates/gutenberg-create.html
+++ b/webui/templates/gutenberg-create.html
@@ -1,0 +1,65 @@
+<html>
+<head>
+	<title>The Distant Reader - Project Gutenberg to study carrel</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<link rel="stylesheet" href="/etc/style.css">
+	<style>
+		.item { margin-bottom: 1em }
+	</style>
+</head>
+<body>
+<div class="header">
+	<h1>The Distant Reader - Project Gutenberg to study carrel</h1>
+</div>
+
+<div class="col-3 col-m-3 menu">
+  <ul>
+		<li style='margin-bottom: 2em'><a href="/">Distant Reader home</a></li>
+		
+		<li ><a href="/file2carrel/">File to study carrel</a></li>
+		<li><a href="/zip2carrel/">Zip to study carrel</a></li>
+		<li><a href="/url2carrel/">URL to study carrel</a></li>
+		<li><a href="/urls2carrel/">URLs to study carrel</a></li>
+		<li><a href="/trust2carrel/">HathiTrust to study carrel</a></li>
+		<li style='margin-bottom: 2em'><a href="/biorxiv2carrel/">Biorxiv to study carrel</a></li>
+		
+		<li><a href="/gutenberg/">Project Gutenberg to study carrel</a></li>
+		<li><a href="/cord/">COVID-19 to study carrel</a></li>
+		
+ </ul>
+</div>
+
+<div class="col-9 col-m-9">
+
+	<p>Use this form to queue the creation of a study carrel with the results of your search.</p>
+	
+	<form method='GET'>
+        <input type='hidden' name="query" value='{{ query }}' />
+	<table>
+		<tr>
+			<td style='text-align:right'>Short name:</td>
+			<td><input type='text'
+			           name='shortname'
+			           autofocus="autofocus"
+			           onkeyup="this.value = this.value.replace( /[^a-z|^A-Z|0-9|_|\-]/, '' )" />
+			</td>
+		</tr>
+		<tr>
+			<td style='text-align:right'>Action</td>
+			<td><input type='submit' name='queue' value='Queue' /></td>
+		<tr>
+	</table>
+	
+	</form>
+
+	<div class="footer">
+		<p style='text-align: right'>
+		Eric Lease Morgan &amp; Team Project Gutenberg<br />
+		November 26, 2020
+		</p>
+	</div>
+
+</div>
+
+</body>
+</html>

--- a/webui/templates/gutenberg-queue.html
+++ b/webui/templates/gutenberg-queue.html
@@ -1,0 +1,46 @@
+<html>
+<head>
+	<title>The Distant Reader - Project Gutenberg to study carrel</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<link rel="stylesheet" href="/etc/style.css">
+	<style>
+		.item { margin-bottom: 1em }
+	</style>
+</head>
+<body>
+<div class="header">
+	<h1>The Distant Reader - Project Gutenberg to study carrel</h1>
+</div>
+
+<div class="col-3 col-m-3 menu">
+  <ul>
+		<li style='margin-bottom: 2em'><a href="/">Distant Reader home</a></li>
+		
+		<li ><a href="/file2carrel/">File to study carrel</a></li>
+		<li><a href="/zip2carrel/">Zip to study carrel</a></li>
+		<li><a href="/url2carrel/">URL to study carrel</a></li>
+		<li><a href="/urls2carrel/">URLs to study carrel</a></li>
+		<li><a href="/trust2carrel/">HathiTrust to study carrel</a></li>
+		<li style='margin-bottom: 2em'><a href="/biorxiv2carrel/">Biorxiv to study carrel</a></li>
+		
+		<li><a href="/gutenberg/">Project Gutenberg to study carrel</a></li>
+		<li><a href="/cord/">COVID-19 to study carrel</a></li>
+		
+ </ul>
+</div>
+
+<div class="col-9 col-m-9">
+
+    <p><strong>{{ username }}</strong>, your carrel has been queued for creation. Thank you for your submission!</p>
+	
+	<div class="footer">
+		<p style='text-align: right'>
+		Eric Lease Morgan &amp; Team Project Gutenberg<br />
+		November 26, 2020
+		</p>
+	</div>
+
+</div>
+
+</body>
+</html>

--- a/webui/templates/gutenberg-results.html
+++ b/webui/templates/gutenberg-results.html
@@ -1,0 +1,95 @@
+<html>
+<head>
+	<title>The Distant Reader - Project Gutenberg to study carrel</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<link rel="stylesheet" href="/etc/style.css">
+	<style>
+		.item { margin-bottom: 1em }
+	</style>
+</head>
+<body>
+<div class="header">
+	<h1>The Distant Reader - Project Gutenberg to study carrel</h1>
+</div>
+
+<div class="col-3 col-m-3 menu">
+  <ul>
+		<li style='margin-bottom: 2em'><a href="/">Distant Reader home</a></li>
+		
+		<li ><a href="/file2carrel/">File to study carrel</a></li>
+		<li><a href="/zip2carrel/">Zip to study carrel</a></li>
+		<li><a href="/url2carrel/">URL to study carrel</a></li>
+		<li><a href="/urls2carrel/">URLs to study carrel</a></li>
+		<li><a href="/trust2carrel/">HathiTrust to study carrel</a></li>
+		<li style='margin-bottom: 2em'><a href="/biorxiv2carrel/">Biorxiv to study carrel</a></li>
+		
+		<li><a href="/gutenberg/">Project Gutenberg to study carrel</a></li>
+		<li><a href="/cord/">COVID-19 to study carrel</a></li>
+		
+ </ul>
+</div>
+
+	<div class="col-6 col-m-6">
+		<p>
+		<form method='GET' action=''>
+			Query: <input type='text' name='query' value='{{ query }}' size='50' autofocus="autofocus"/>
+		<input type='submit' value='Search' />
+		</form>
+
+		<p>Your search found {{ total_hits }} item(s) and {{ num_displayed }} item(s) are displayed. If you are satisfied with the results, then you may want to <a href='{{ url_for('create_gutenberg', query=query) }}'>queue the creation of a study carrel</a> with them.</p>	
+
+	<h3>Items</h3>
+	<ol>
+		{%- for item in results %}
+		<li class='item'>
+			<a href='{{ item['file'] }}'>{{ item['title'] }}</a>
+			<ul>
+				{%- if item['author'] -%}
+				<li style='list-style-type:circle'>
+					<a href='?query=author:"{{ item['author'] }}"'>{{ item['author'] }}</a>
+				</li>
+				{%- endif -%}
+				{%- if item['subject'] -%}
+				<li style='list-style-type:circle'>
+					{%- for subject in item['subject'] -%}
+					{{ loop.index | roman_numeral }}. <a href='?query=subject:"{{ subject }}"'>{{ subject }}</a>
+					{% endfor -%}
+				</li>
+				{%- endif -%}
+				{%- if item['classification'] -%}
+				<li style='list-style-type:circle'>
+					{%- for classification in item['classification'] -%}
+					<a href='?query=classification:"{{ classification }}"'>{{ classification }}</a>
+					{%- if not loop.last %};{% endif -%}
+					{%- endfor -%}
+				</li>
+				{%- endif -%}
+				<li style='list-style-type:circle'>{{ item['gid'] }}</li>
+			</ul>
+		</li>
+		{%- endfor -%}
+	</ol>
+		
+	</div>
+	
+	<div class="col-3 col-m-3">
+		<h3>Author facets</h3>
+		<p>{% for author, count in author_facets.items() %}
+			<a href='?query={{ query }} AND author:"{{ author }}"'>{{ author }}</a> ({{ count }});
+		{%- endfor -%}
+		</p>
+
+		<h3>Subject facets</h3>
+		<p>{% for k,v in subject_facets.items() %}
+			<a href='?query={{ query }} AND subject:"{{ k }}"'>{{ k }}</a> ({{ v }});
+		{%- endfor -%}
+		</p>
+
+		<h3>Classification facets</h3>
+		<p>{% for k,v in classification_facets.items() %}
+			<a href='?query={{ query }} AND classification:"{{ k }}"'>{{ k }}</a> ({{ v }});
+		{%- endfor -%}
+		</p>
+	</div>
+</body>
+</html>

--- a/webui/templates/gutenberg-results.html
+++ b/webui/templates/gutenberg-results.html
@@ -13,7 +13,7 @@
 </div>
 
 <div class="col-3 col-m-3 menu">
-  <ul>
+	<ul>
 		<li style='margin-bottom: 2em'><a href="/">Distant Reader home</a></li>
 		
 		<li ><a href="/file2carrel/">File to study carrel</a></li>
@@ -26,17 +26,17 @@
 		<li><a href="/gutenberg/">Project Gutenberg to study carrel</a></li>
 		<li><a href="/cord/">COVID-19 to study carrel</a></li>
 		
- </ul>
+	</ul>
 </div>
 
-	<div class="col-6 col-m-6">
-		<p>
-		<form method='GET' action=''>
-			Query: <input type='text' name='query' value='{{ query }}' size='50' autofocus="autofocus"/>
-		<input type='submit' value='Search' />
-		</form>
+<div class="col-6 col-m-6">
+	<p>
+	<form method='GET' action=''>
+		Query: <input type='text' name='query' value='{{ query }}' size='50' autofocus="autofocus"/>
+	<input type='submit' value='Search' />
+	</form></p>
 
-		<p>Your search found {{ total_hits }} item(s) and {{ num_displayed }} item(s) are displayed. If you are satisfied with the results, then you may want to <a href='{{ url_for('create_gutenberg', query=query) }}'>queue the creation of a study carrel</a> with them.</p>	
+	<p>Your search found {{ total_hits }} item(s) and {{ num_displayed }} item(s) are displayed. If you are satisfied with the results, then you may want to <a href='{{ url_for('create_gutenberg', query=query) }}'>queue the creation of a study carrel</a> with them.</p>
 
 	<h3>Items</h3>
 	<ol>
@@ -69,27 +69,23 @@
 		</li>
 		{%- endfor -%}
 	</ol>
-		
-	</div>
-	
-	<div class="col-3 col-m-3">
-		<h3>Author facets</h3>
-		<p>{% for author, count in author_facets.items() %}
-			<a href='?query={{ query }} AND author:"{{ author }}"'>{{ author }}</a> ({{ count }});
-		{%- endfor -%}
-		</p>
+</div>
 
-		<h3>Subject facets</h3>
-		<p>{% for k,v in subject_facets.items() %}
-			<a href='?query={{ query }} AND subject:"{{ k }}"'>{{ k }}</a> ({{ v }});
+<div class="col-3 col-m-3">
+	{% macro add_facet(title, query_field, facet_field) %}
+		{% if facets[facet_field] %}
+		<h3>{{ title }}</h3>
+		<p>
+		{% for term, count in facets[facet_field] %}
+			<a href='?query={{ query }} AND {{ query_field }}:"{{ term }}"'>{{ term }}</a> ({{ count }});
 		{%- endfor -%}
 		</p>
+		{% endif %}
+	{% endmacro %}
 
-		<h3>Classification facets</h3>
-		<p>{% for k,v in classification_facets.items() %}
-			<a href='?query={{ query }} AND classification:"{{ k }}"'>{{ k }}</a> ({{ v }});
-		{%- endfor -%}
-		</p>
-	</div>
+	{{ add_facet("Author facets", "author", "facet_author") }}
+	{{ add_facet("Subject facets", "subject", "facet_subject") }}
+	{{ add_facet("Classification facets", "classification", "facet_classification") }}
+</div>
 </body>
 </html>

--- a/webui/templates/gutenberg.html
+++ b/webui/templates/gutenberg.html
@@ -1,0 +1,53 @@
+<html>
+<head>
+	<title>The Distant Reader - Project Gutenberg to study carrel</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<link rel="stylesheet" href="/etc/style.css">
+	<style>
+		.item { margin-bottom: 1em }
+	</style>
+</head>
+<body>
+<div class="header">
+	<h1>The Distant Reader - Project Gutenberg to study carrel</h1>
+</div>
+
+<div class="col-3 col-m-3 menu">
+  <ul>
+		<li style='margin-bottom: 2em'><a href="/">Distant Reader home</a></li>
+		
+		<li ><a href="/file2carrel/">File to study carrel</a></li>
+		<li><a href="/zip2carrel/">Zip to study carrel</a></li>
+		<li><a href="/url2carrel/">URL to study carrel</a></li>
+		<li><a href="/urls2carrel/">URLs to study carrel</a></li>
+		<li><a href="/trust2carrel/">HathiTrust to study carrel</a></li>
+		<li style='margin-bottom: 2em'><a href="/biorxiv2carrel/">Biorxiv to study carrel</a></li>
+		
+		<li><a href="/gutenberg/">Project Gutenberg to study carrel</a></li>
+		<li><a href="/cord/">COVID-19 to study carrel</a></li>
+		
+ </ul>
+</div>
+
+<div class="col-9 col-m-9">
+
+	<p>This is selected fulltext index to the content of Project Project Gutenberg. Enter a query.</p>
+	<p>
+	<form method='GET'>
+		Query: <input type='text' name='query' value='{{ query }}' size='50' autofocus="autofocus"/>
+	<input type='submit' value='Search' />
+	</form>
+
+	##RESULTS##
+
+	<div class="footer">
+		<p style='text-align: right'>
+		Eric Lease Morgan<br />
+		November 26, 2020
+		</p>
+	</div>
+
+</div>
+
+</body>
+</html>

--- a/webui/templates/gutenberg.html
+++ b/webui/templates/gutenberg.html
@@ -38,8 +38,6 @@
 	<input type='submit' value='Search' />
 	</form>
 
-	##RESULTS##
-
 	<div class="footer">
 		<p style='text-align: right'>
 		Eric Lease Morgan<br />

--- a/webui/templates/home.html
+++ b/webui/templates/home.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Distant Reader - Home</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<style>
+		body { font-family: Georgia, serif; }
+		h1,h2 {font-family: Verdana, sans-serif}
+		ol.whatshere li {margin-top: 1em}
+	</style>
+</head>
+<body style="margin-left: 3%; margin-right:3%; margin-top: 3%; margin-bottom: 3%">
+<h1 style='text-align:center'>
+	The Distant Reader, a tool for reading stuff
+</h1>
+<p>
+	<img src='/etc/banner.jpg' alt='banner' style="max-width:50%;height:auto;float:right;margin-left:1em" />Intended for anybody who reads, the Distant Reader takes text as input, does analysis against it, and outputs sets of structured data, affectionately called "<strong>study carrels</strong>". The student, research, or scholar can then use a study carrel to read the text both closely as well as at a distance.
+</p>
+<a id='inventory'> 
+<h2>
+	What's here
+</h2>
+<ol class="whatshere">
+	<li><a href="http://library.distantreader.org/catalog/">Library "catalog</a>" - a simple &amp; rudimentary list of curated study carrels</li>
+    <li><a href="https://library.distantreader.org/patrons/">Patrons / sign in</a> - if you have created study carrels, then you can log in to see them here; if you would like to create study carrels, then <a href="mailto:emorgan@nd.edu?subject=[distantreader]%20password%20request">request a username/passsword</a></li>
+	<li>Interfaces for creating study carrels: 
+	<ul>
+		<li>carrels with data you supply
+		<ol>
+			<li>a <a href="{{ url_for('file2carrel') }}">file</a> - quick &amp; easy, but is really only useful for "large" files like entire books</li>
+			<li>a <a href="{{ url_for('zip2carrel') }}">Zip file</a> - save files of just about any type in a folder/directory on your computer, compress (zip) the folder, and submit the results; great for those journal articles you downloaded for your research paper or the items in your class's reading list</li>
+			<li>a <a href="{{ url_for('url2carrel') }}">URL</a> - quick &amp; easy, but the content may not be accesible by the Reader and the results may be overwhelmed with website navigation information; try Wikipedia pages, a blog, or a departmental website</li>
+			<li>a <a href="{{ url_for('urls2carrel') }}">list of URLs</a> - like creating carrels from a single URL but more targeted and more scalable; consider creating a study carrel, and use the list of extracted URLs as the input for this service</li>
+		</ol>
+		</li>
+		<li>carrels with data from external services
+		<ul>
+			<li><a href="/trust2carrel/">HathiTrust</a> - millions of books in the public domain; <a href="https://www.hathitrust.org">search the 'Trust</a>, add items to your "collection", download your or somebody else's collection file, and use it as input for this service</li>
+			<li><a href="/biorxiv2carrel/">bioRxiv</a> - a pre-print server for biology; <a href="https://www.biorxiv.org">search bioRxiv</a>, mark items of interest, download the list of selected items as an "XML" file, and use the result as the input for this service</li>
+		</ul>
+		</li>
+		<li>carrels with data from local indexes
+		<ul>
+			<li><a href="/gutenberg/">Project Gutenberg</a> - a local cache of the about 30,000 public domain documents from the venerable Project Gutenberg; submit a query, and create a carrel from the results; very easy and almost all queries will return something; great for "big" ideas (like <a href="/gutenberg/?query=subject%3A%22Love%22">love</a>, <a href="/gutenberg/?query=subject%3A%22war%22">war</a>, or <a href="/gutenberg/?query=subject%3A%22knowledge%22">knowledge</a>), "classic" authors (like <a href="/gutenberg/?query=author%3A%22Plato%22">Plato</a>, <a href="/gutenberg/?query=author:shakespeare%20AND%20author:%22Shakespeare,%20William%22">Shakespeare</a>, or <a href="/gutenberg/?query=author%3A%22Austen%2C+Jane%22">Jane Austen</a>), or types of literature (like <a href="/gutenberg/?query=subject%3A%22Romances%22">Romances</a>, <a href="/gutenberg/?query=subject:%22Western%20stories%22">Westerns</a>, or <a href="/gutenberg/?query=subject:%22Science%20fiction%22">Science Fiction</a>)
+			<li><a href="/cord/">CORD-19</a> - a cache of more than 100,000 scholarly and scientific journal articles on the topic of COVID-19; based on <a href="https://www.semanticscholar.org/cord19">a data set by the same name</a>, this index can be used to create study carrels based on topics (like <a href="/cord/?query=%28+%28+*+NOT+%28+pdf_json%3Anan+%29+%29+OR+%28+*+NOT+%28+pmc_json%3Anan+%29+%29+%29+AND+%28title%3Ainfection*+AND+entity%3Ainfection*+AND+keywords%3Ainfection*%29">infection</a>, <a href="/cord/?query=%28+%28+*+NOT+%28+pdf_json%3Anan+%29+%29+OR+%28+*+NOT+%28+pmc_json%3Anan+%29+%29+%29+AND+%28title%3Avaccine*+AND+entity%3A+vaccine*+AND+keywords%3A+vaccine*%29">vaccines</a>, or <a href="/cord/?query=%28+%28+*+NOT+%28+pdf_json%3Anan+%29+%29+OR+%28+*+NOT+%28+pmc_json%3Anan+%29+%29+%29+AND+%28title%3Asars*+AND+entity%3A+sars*+AND+keywords%3A+sars*%29">SARS</a>) or journals titles (like <a href="/cord/?query=(%20(%20*%20NOT%20(%20pdf_json:nan%20)%20)%20OR%20(%20*%20NOT%20(%20pmc_json:nan%20)%20)%20)%20AND%20facet_journal:%22Lancet%22">Lancet</a>, <a href="/cord/?query=(%20(%20*%20NOT%20(%20pdf_json:nan%20)%20)%20OR%20(%20*%20NOT%20(%20pmc_json:nan%20)%20)%20)%20AND%20facet_journal:%22PLoS%20One%22">PLoS One</a>, or <a href="/cord/?query=(%20(%20*%20NOT%20(%20pdf_json:nan%20)%20)%20OR%20(%20*%20NOT%20(%20pmc_json:nan%20)%20)%20)%20AND%20facet_journal:%22J%20Med%20Virol%22">Journal of Medical Virology</a>) </li>
+		</ul>
+		</li>
+	</ul>
+	</li>
+	<li><a href="http://cord.distantreader.org/">Project CORD</a> - an "archived" website originally sponsored by the <a href="https://covid19-hpc-consortium.org">COVID-19 HPC Consortium</a> for the purposes of indexing &amp; providing access to <a href="https://www.semanticscholar.org/cord19">CORD-19</a></li>
+</ol>
+</a>
+<h2>
+	About
+</h2>
+<p>
+	Through the use of study carrels, the student, researcher or scholar can easily ask and answer questions such as but not limited to:
+</p>
+<ul>
+	<li>Who or what is mentioned in this corpus?</li>
+	<li>What do they do?</li>
+	<li>When does the action take place?</li>
+	<li>Where does the action take place?</li>
+	<li>How are they described?</li>
+	<li>What themes exist in a corpus and how are the manifested over time or between writers?</li>
+</ul>
+<p>
+	Study carrels are also useful tools for getting your mind around large corpora because they provide ways to sort, group, and prioritized their content.
+</p>
+<p>
+	The key to getting the most out of the Distant Reader is two-fold:
+</p>
+<ol>
+	<li>articulating a question you would like to address, and</li>
+	<li>identifying a corpus which may be used to answer the question</li>
+</ol>
+<p>
+	The questions can be as rudimentary as "What words are used most frequently in <cite>Moby Dick</cite>?" or as sublime as "How was love defined during the 19th Century?"
+</p>
+<p>
+	Study carrels can be created from but not limited to: websites, blogs, social media feeds, or files from your computer. The Reader can analyze just about any type of file including but not limited to: Portable Document Format (.pdf) files, Word (.doc and docx) documents, PowerPoint (.ppt and pptx) files, HTML (.htm and .html) files, plain text (.txt) files, XML (.xml) files, etc.
+</p>
+<h2>
+	People &amp; Sponsors
+</h2>
+<p>
+	Sincere and heart-felt thanks go out to the following people and sponsors; "It takes a village." 
+</p>
+<div style='text-align: center'>
+	<p>
+		<img src='/etc/wordle.png' alt='wordle' style="max-width:100%;height:auto;" />
+	</p>
+	<p>
+		<img src='/etc/xsede.jpg' align="middle" alt='xsede' style="max-width:33%;height:auto;" /> <img src='/etc/nfcds.png' align="middle" alt='nfcds' style="max-width:33%;height:auto;" /> <img src='/etc/scigap.png' align="middle" alt='schigap' style="max-width:33%;height:auto;" />
+	</p>
+	<p>
+		<img src='/etc/microsoft.png' align="middle" alt='microsoft' style="max-width:25%;height:auto;" /> <img src='/etc/airavata.png' align="middle" alt='airavata' style="max-width:25%;height:auto;" /> <img src='/etc/nsf.png' align="middle" alt='nsf' style="max-width:25%;height:auto;" /> <img src='/etc/lanl.png' align="middle" alt='lanl' style="max-width:25%;height:auto;" />
+	</p>
+</div>
+<h2>Software</h2>
+<p>
+	From a computer system's point of view, the Distant Reader is really the amalgamation of differents sets of computer software tools used to create a (hopefully) useful and interesting service. Much of that software inclues, but is not limited to:
+</p>
+<ul>
+	<li><a href="https://airavata.apache.org/">Airivata</a> - used to submit and monitor large-scale applications</li>
+	<li><a href="https://metacpan.org/pod/Archive::Zip">Archive::Zip</a> - a Perl library to create Zip files</li>
+	<li><a href="https://getbootstrap.com/">bootstrap</a> - a library of Javascript and CSS functions</li>
+	<li><a href="https://metacpan.org/pod/distribution/CGI/lib/CGI.pod">CGI</a> - A Perl module for creating CGI scripts</li>
+	<li><a href="http://csvkit.rtfd.org/">csvstack</a> - a set of command-line tool reading tabular data </li>
+	<li><a href="https://metacpan.org/pod/DBI">DBI</a> - a Perl library to do I/O against databases</li>
+	<li><a href="https://metacpan.org/pod/File::Basename">File::Basename</a> - a Perl library to process file names</li>
+	<li><a href="https://metacpan.org/pod/File::Copy">File::Copy</a> - a Perl library used to copy files</li>
+	<li><a href="https://radimrehurek.com/gensim/">Gensim</a> - a Python library for natural language processing</li>
+	<li><a href="https://metacpan.org/pod/HTML::Entities">HTML::Entities</a> - a Perl library for encoding data for the Web</li>
+	<li><a href="https://jquery.com/">jquery</a> - a Javascript library for user-interface</li>
+	<li><a href="https://metacpan.org/pod/JSON">JSON</a> - a Perl library for reading JSON data</li>
+	<li><a href="https://matplotlib.org/mpl_toolkits/">mpl_toolkits</a> - a Python library for generating charts &amp; graphs</li>
+	<li><a href="https://networkx.github.io/">networkx</a> - a Javascript library for creating network diagrams</li>
+	<li><a href="https://www.nltk.org/">nltk</a> - a Python library for natural language processing</li>
+	<li><a href="https://www.openstack.org/">OpenStack</a> - a Linux toolkit for creating virtual machines</li>
+	<li><a href="https://pandas.pydata.org/">pandas</a> - a Python library for processing matrix-based data</li>
+	<li><a href="https://scikit-learn.org/">sklearn</a> - a Python library for machine learning</li>
+	<li><a href="https://slurm.schedmd.com/">Slurm</a> - a Linux toolkit to support cluster computing</li>
+	<li><a href="https://spacy.io">SpaCy</a> - a Python library for natural language processing</li>
+	<li><a href="https://www.sqlalchemy.org/">SQLAlchemy</a> - a Python library for interacting with databases</li>
+	<li><a href="https://www.sqlite.org/index.html">SQLite</a> - a C library-based relational database</li>
+	<li><a href="http://www.erinhengel.com/software/textatistic/">Textacy</a> - a Python library for natural language processing</li>
+	<li><a href="https://tika.apache.org">Tika</a> - a Java archive for text pre-processing</li>
+	<li><a href="https://metacpan.org/pod/WebService::Solr">WebService::Solr</a> - a Perl library used to interact with a Solr index</li>
+	<li><a href="https://www.gnu.org/software/wget/">Wget</a> - a HTTP user-agent</li>
+	<li><a href="https://github.com/amueller/word_cloud">wordcloud</a> - a Python library for creating word clouds</li>
+	<li><a href="https://metacpan.org/pod/XML::XPath">XML::XPath</a> - a Perl library for querying XML </li>
+</ul>
+<p>All of the code to the Distant Reader is located in a number of different GitHub repositories. If you would like to contribute, then please see "<a href="https://github.com/ericleasemorgan/reader/blob/master/CONTRIBUTING.md">Contributing to the Distant Reader</a>". Software is never done, and if it were, then it would be called "hardware".</p>
+
+<hr />
+<p style='text-align: right'>
+	Eric Lease Morgan &lt;<a href="mailto:emorgan@nd.edu">emorgan@nd.edu</a>&gt;<br />
+	University of Notre Dame<br />
+	<br />
+	January 17, 2021 
+</p>
+</body>
+</html>

--- a/webui/templates/trust2carrel-queue.html
+++ b/webui/templates/trust2carrel-queue.html
@@ -1,0 +1,46 @@
+<html>
+<head>
+	<title>The Distant Reader - HathiTrust metadata file to study carrel</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<link rel="stylesheet" href="/etc/style.css">
+	<style>
+		.item { margin-bottom: 1em }
+	</style>
+</head>
+<body>
+<div class="header">
+	<h1>The Distant Reader - HathiTrust metadata file to study carrel</h1>
+</div>
+
+<div class="col-3 col-m-3 menu">
+  <ul>
+		<li style='margin-bottom: 2em'><a href="/">Distant Reader home</a></li>
+		
+		<li ><a href="/file2carrel/">File to study carrel</a></li>
+		<li><a href="/zip2carrel/">Zip to study carrel</a></li>
+		<li><a href="/url2carrel/">URL to study carrel</a></li>
+		<li><a href="/urls2carrel/">URLs to study carrel</a></li>
+		<li>HathiTrust to study carrel</li>
+		<li style='margin-bottom: 2em'><a href="/biorxiv2carrel/">Biorxiv to study carrel</a></li>
+		
+		<li><a href="/gutenberg/">Gutenberg to study carrel</a></li>
+		<li><a href="/cord/">COVID-19 to study carrel</a></li>
+		
+ </ul>
+</div>
+
+<div class="col-9 col-m-9">
+
+	<p><strong>{{ username }}</strong>, your carrel has been queued for creation. Thank you for your submission!</p>
+	
+	<div class="footer">
+		<p style='text-align: right'>
+		Eric Lease Morgan<br />
+		November 29, 2020
+		</p>
+	</div>
+
+</div>
+
+</body>
+</html>

--- a/webui/templates/trust2carrel.html
+++ b/webui/templates/trust2carrel.html
@@ -1,0 +1,67 @@
+<html>
+<head>
+	<title>The Distant Reader - HathiTrust metadata file to study carrel</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<link rel="stylesheet" href="/etc/style.css">
+	<style>
+		.item { margin-bottom: 1em }
+	</style>
+</head>
+<body>
+<div class="header">
+	<h1>The Distant Reader - HathiTrust metadata file to study carrel</h1>
+</div>
+
+<div class="col-3 col-m-3 menu">
+  <ul>
+		<li style='margin-bottom: 2em'><a href="/">Distant Reader home</a></li>
+		
+		<li ><a href="/file2carrel/">File to study carrel</a></li>
+		<li><a href="/zip2carrel/">Zip to study carrel</a></li>
+		<li><a href="/url2carrel/">URL to study carrel</a></li>
+		<li><a href="/urls2carrel/">URLs to study carrel</a></li>
+		<li>HathiTrust to study carrel</li>
+		<li style='margin-bottom: 2em'><a href="/biorxiv2carrel/">Biorxiv to study carrel</a></li>
+		
+		<li><a href="/gutenberg/">Gutenberg to study carrel</a></li>
+		<li><a href="/cord/">COVID-19 to study carrel</a></li>
+		
+ </ul>
+</div>
+
+<div class="col-9 col-m-9">
+
+	<p>Use this form to queue a HathiTrust metadata (.tsv) file to be processed by the Distant Reader.</p>
+	
+	<form action="./" method="post" enctype="multipart/form-data">
+	<table>
+		<tr>
+			<td style='text-align:right'>One-word name describing your carrel:</td>
+			<td><input type='text'
+			           name='shortname'
+			           autofocus="autofocus"
+			           onkeyup="this.value = this.value.replace( /[^a-z|^A-Z|0-9|_|\-]/, '' )" />
+			</td>
+		</tr>
+		<tr>
+			<td style='text-align:right'>HathiTrust metadata file:</td>
+			<td><input type="file" name="tsv" accept=".tsv" /></td>
+		</tr>
+			<td style='text-align:right'>Action</td>
+			<td><input type='submit' name='queue' value='Queue the file' /></td>
+		<tr>
+	</table>
+	
+	</form>
+
+	<div class="footer">
+		<p style='text-align: right'>
+		Eric Lease Morgan<br />
+		November 29, 2020
+		</p>
+	</div>
+
+</div>
+
+</body>
+</html>

--- a/webui/templates/url2carrel.html
+++ b/webui/templates/url2carrel.html
@@ -1,0 +1,67 @@
+<html>
+<head>
+	<title>The Distant Reader - URL to study carrel</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<link rel="stylesheet" href="/etc/style.css">
+	<style>
+		.item { margin-bottom: 1em }
+	</style>
+</head>
+<body>
+<div class="header">
+	<h1>The Distant Reader - URL to study carrel</h1>
+</div>
+
+<div class="col-3 col-m-3 menu">
+  <ul>
+		<li style='margin-bottom: 2em'><a href="/">Distant Reader home</a></li>
+		
+		<li><a href="/file2carrel/">File to study carrel</a></li>
+		<li><a href="/zip2carrel/">Zip to study carrel</a></li>
+		<li>URL to study carrel</li>
+		<li><a href="/urls2carrel/">URLs to study carrel</a></li>
+		<li><a href="/trust2carrel/">HathiTrust to study carrel</a></li>
+		<li style='margin-bottom: 2em'><a href="/biorxiv2carrel/">Biorxiv to study carrel</a></li>
+		
+		<li><a href="/gutenberg/">Gutenberg to study carrel</a></li>
+		<li><a href="/cord/">COVID-19 to study carrel</a></li>
+		
+ </ul>
+</div>
+
+<div class="col-9 col-m-9">
+
+	<p>Use this form to queue the creation of a study carrel based on the content of a URL.</p>
+	
+	<form method='GET' action=''>
+	<table>
+		<tr>
+			<td style='text-align:right'>Short name:</td>
+			<td><input type='text'
+			           name='shortname'
+			           autofocus="autofocus"
+			           onkeyup="this.value = this.value.replace( /[^a-z|^A-Z|0-9|_|\-]/, '' )" />
+			</td>
+		</tr>
+		<tr>
+			<td style='text-align:right'>URL:</td>
+			<td><input name="url" /></td>
+		</tr>
+			<td style='text-align:right'>Action</td>
+			<td><input type='submit' name='queue' value='Queue' /></td>
+		<tr>
+	</table>
+	
+	</form>
+
+	<div class="footer">
+		<p style='text-align: right'>
+		Eric Lease Morgan<br />
+		November 28, 2020
+		</p>
+	</div>
+
+</div>
+
+</body>
+</html>

--- a/webui/templates/urls2carrel-queue.html
+++ b/webui/templates/urls2carrel-queue.html
@@ -1,0 +1,46 @@
+<html>
+<head>
+	<title>A list of URLs to study carrel</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<link rel="stylesheet" href="/etc/style.css">
+	<style>
+		.item { margin-bottom: 1em }
+	</style>
+</head>
+<body>
+<div class="header">
+	<h1>A list of URLs to study carrel</h1>
+</div>
+
+<div class="col-3 col-m-3 menu">
+  <ul>
+		<li style='margin-bottom: 2em'><a href="/">Distant Reader home</a></li>
+		
+		<li ><a href="/file2carrel/">File to study carrel</a></li>
+		<li><a href="/zip2carrel/">Zip to study carrel</a></li>
+		<li><a href="/url2carrel/">URL to study carrel</a></li>
+		<li>URLs to study carrel</li>
+		<li><a href="/trust2carrel/">HathiTrust to study carrel</a></li>
+		<li style='margin-bottom: 2em'><a href="/biorxiv2carrel/">Biorxiv to study carrel</a></li>
+		
+		<li><a href="/gutenberg/">Gutenberg to study carrel</a></li>
+		<li><a href="/cord/">COVID-19 to study carrel</a></li>
+		
+ </ul>
+</div>
+
+<div class="col-9 col-m-9">
+
+    <p><strong>{{ username }}</strong>, your carrel <strong>{{ shortname }}</strong> has been queued for creation. Thank you for your submission!</p>
+	
+	<div class="footer">
+		<p style='text-align: right'>
+		Eric Lease Morgan<br />
+		November 29, 2020
+		</p>
+	</div>
+
+</div>
+
+</body>
+</html>

--- a/webui/templates/urls2carrel.html
+++ b/webui/templates/urls2carrel.html
@@ -1,0 +1,66 @@
+<html>
+<head>
+	<title>The Distant Reader - A list of URLs to study carrel</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<link rel="stylesheet" href="/etc/style.css">
+	<style>
+		.item { margin-bottom: 1em }
+	</style>
+</head>
+<body>
+<div class="header">
+	<h1>The Distant Reader - A list of URLs to study carrel</h1>
+</div>
+
+<div class="col-3 col-m-3 menu">
+  <ul>
+		<li style='margin-bottom: 2em'><a href="/">Distant Reader home</a></li>
+		
+		<li ><a href="/file2carrel/">File to study carrel</a></li>
+		<li><a href="/zip2carrel/">Zip to study carrel</a></li>
+		<li><a href="/url2carrel/">URL to study carrel</a></li>
+		<li>URLs to study carrel</li>
+		<li><a href="/trust2carrel/">HathiTrust to study carrel</a></li>
+		<li style='margin-bottom: 2em'><a href="/biorxiv2carrel/">Biorxiv to study carrel</a></li>
+		
+		<li><a href="/gutenberg/">Gutenberg to study carrel</a></li>
+		<li><a href="/cord/">COVID-19 to study carrel</a></li>
+		
+ </ul>
+</div>
+
+<div class="col-9 col-m-9">
+
+	<p>Use this form to queue a plain text file (a list) of URLs to be processed by the Distant Reader.</p>
+	
+	<form action="" method="post" enctype="multipart/form-data">
+	<table>
+		<tr>
+			<td style='text-align:right'>One-word name describing your carrel:</td>
+			<td><input type='text'
+			           name='shortname'
+			           autofocus="autofocus"
+			           onkeyup="this.value = this.value.replace( /[^a-z|^A-Z|0-9|_|\-]/, '' )" />
+			</td>
+		</tr>
+		<tr>
+			<td style='text-align:right'>Plain text file (a list) of URLs:</td>
+			<td><input type="file" name="urls" accept=".txt" /></td>
+		</tr>
+			<td style='text-align:right'>Action</td>
+			<td><input type='submit' name='queue' value='Queue the file' /></td>
+		<tr>
+	</table>
+	</form>
+
+	<div class="footer">
+		<p style='text-align: right'>
+		Eric Lease Morgan<br />
+		November 29, 2020
+		</p>
+	</div>
+
+</div>
+
+</body>
+</html>

--- a/webui/templates/zip2carrel-queue.html
+++ b/webui/templates/zip2carrel-queue.html
@@ -1,0 +1,46 @@
+<html>
+<head>
+	<title>Zip file to study carrel</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<link rel="stylesheet" href="/etc/style.css">
+	<style>
+		.item { margin-bottom: 1em }
+	</style>
+</head>
+<body>
+<div class="header">
+	<h1>Zip file to study carrel</h1>
+</div>
+
+<div class="col-3 col-m-3 menu">
+  <ul>
+		<li style='margin-bottom: 2em'><a href="/">Distant Reader home</a></li>
+		
+		<li><a href="/file2carrel/">File to study carrel</a></li>
+		<li>Zip to study carrel</li>
+		<li><a href="/url2carrel/">URL to study carrel</a></li>
+		<li><a href="/urls2carrel/">URLs to study carrel</a></li>
+		<li><a href="/trust2carrel/">HathiTrust to study carrel</a></li>
+		<li style='margin-bottom: 2em'><a href="/biorxiv2carrel/">Biorxiv to study carrel</a></li>
+		
+		<li><a href="/gutenberg/">Gutenberg to study carrel</a></li>
+		<li><a href="/cord/">COVID-19 to study carrel</a></li>
+		
+ </ul>
+</div>
+
+<div class="col-9 col-m-9">
+
+    <p><strong>{{ username }}</strong>, your carrel <strong>{{ shortname }}</strong> has been queued for creation. Thank you for your submission!</p>
+	
+	<div class="footer">
+		<p style='text-align: right'>
+		Eric Lease Morgan<br />
+		November 29, 2020
+		</p>
+	</div>
+
+</div>
+
+</body>
+</html>

--- a/webui/templates/zip2carrel.html
+++ b/webui/templates/zip2carrel.html
@@ -1,0 +1,67 @@
+<html>
+<head>
+	<title>The Distant Reader - Zip file to study carrel</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<link rel="stylesheet" href="/etc/style.css">
+	<style>
+		.item { margin-bottom: 1em }
+	</style>
+</head>
+<body>
+<div class="header">
+	<h1>The Distant Reader - Zip file to study carrel</h1>
+</div>
+
+<div class="col-3 col-m-3 menu">
+  <ul>
+		<li style='margin-bottom: 2em'><a href="/">Distant Reader home</a></li>
+		
+		<li><a href="/file2carrel/">File to study carrel</a></li>
+		<li>Zip to study carrel</li>
+		<li><a href="/url2carrel/">URL to study carrel</a></li>
+		<li><a href="/urls2carrel/">URLs to study carrel</a></li>
+		<li><a href="/trust2carrel/">HathiTrust to study carrel</a></li>
+		<li style='margin-bottom: 2em'><a href="/biorxiv2carrel/">Biorxiv to study carrel</a></li>
+		
+		<li><a href="/gutenberg/">Gutenberg to study carrel</a></li>
+		<li><a href="/cord/">COVID-19 to study carrel</a></li>
+		
+ </ul>
+</div>
+
+<div class="col-9 col-m-9">
+
+	<p>Use this form to queue a zip file containing any number of other files (plus an optional file named "metadata.csv") to be processed by the Distant Reader.</p>
+	
+	<form action="" method="post" enctype="multipart/form-data">
+	<table>
+		<tr>
+			<td style='text-align:right'>One-word name describing your carrel:</td>
+			<td><input type='text'
+			           name='shortname'
+			           autofocus="autofocus"
+			           onkeyup="this.value = this.value.replace( /[^a-z|^A-Z|0-9|_|\-]/, '' )" />
+			</td>
+		</tr>
+		<tr>
+			<td style='text-align:right'>A zip file:</td>
+			<td><input type="file" name="zip" accept=".zip" /></td>
+		</tr>
+			<td style='text-align:right'>Action</td>
+			<td><input type='submit' name='queue' value='Queue the file' /></td>
+		<tr>
+	</table>
+	
+	</form>
+
+	<div class="footer">
+		<p style='text-align: right'>
+		Eric Lease Morgan<br />
+		November 29, 2020
+		</p>
+	</div>
+
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
Add the cgi functionality to the flask app. It is only missing the page creating study carrels from CORD. This branch was getting too big, so i thought it should be merged in now. Most of the additions are templates for the html pages. Also something is going on with the links because the app is placed in a non-root location in the Apache config. I will look at fixing that. My goal is to have everything working (under the path `/p/`) before swapping it with the cgi stuff.

Also need to set up a docker-compose with a solr and a sample of project gutenberg records.