### PR TITLE
Get apache reverse proxy settings working

### DIFF
--- a/config/httpd-le-ssl.conf
+++ b/config/httpd-le-ssl.conf
@@ -6,8 +6,14 @@
 	DirectoryIndex index.html index.htm index.shtml index.cgi
 	ErrorDocument 401 /etc/401.html
 	<Location "/p">
-		ProxyPass "http://localhost:8000"
-		ProxyPassReverse "http://localhost:8000"
+		AuthType Basic
+		AuthName "Authentication Required"
+		AuthUserFile "/data-disk/etc/reader-htpasswd"
+		Require valid-user
+
+		RequestHeader set SCRIPT_NAME "/p/"
+		ProxyPass "http://localhost:8000/p/"
+		ProxyPassReverse "http://localhost:8000/"
 	</Location>
 	<Directory "/data-disk/www/html/reader">
 		Options All

--- a/config/httpd.conf
+++ b/config/httpd.conf
@@ -382,8 +382,9 @@ HostnameLookups on
 		AuthUserFile "/data-disk/etc/reader-htpasswd"
 		Require valid-user
 
-		ProxyPass "http://localhost:8000"
-		ProxyPassReverse "http://localhost:8000"
+		RequestHeader set SCRIPT_NAME "/p/"
+		ProxyPass "http://localhost:8000/p/"
+		ProxyPassReverse "http://localhost:8000/"
 	</Location>
 
 	<Directory "/data-disk/www/html/reader">

--- a/deploy/deploy-web.sh
+++ b/deploy/deploy-web.sh
@@ -12,13 +12,22 @@ for f in $APACHE_CONFIG_FILES; do
     install -m 666 $f "/etc/httpd/conf/$(basename $f)"
 done
 
+# Copy python service files
+# /sv/reader
+# /opt/reader/env
+# /opt/reader/config.production
+
 # copy all the static files and cgi scripts
 rsync --checksum --recursive www /data-disk/www/html
 
 # copy the python components
-sudo -u app rsync --checksum --recursive webui /opt/reader
+rsync --checksum --recursive webui /opt/reader
+chown -R app:app /opt/reader
+# this needs to run as the app user
 sudo -u app env \
     PIPENV_CACHE_DIR=/opt/reader/pip_cache \
     WORKON_HOME=/opt/reader/pip_cache \
     /usr/local/bin/pipenv install --deploy
+
 sv restart reader
+systemctl reload httpd

--- a/webui/hello.py
+++ b/webui/hello.py
@@ -6,6 +6,7 @@ import pysolr
 
 app = Flask(__name__)
 app.config.from_envvar('READER_CONFIG')
+app.url_map.strict_slashes = False
 
 NUMERALS = {1:'I', 2:'II', 3:'III', 4:'IV', 5:'V',
         6:'VI', 7:'VII', 8:'VIII', 9:'IX', 10:'X',
@@ -210,7 +211,7 @@ def gutenberg():
 
     response = solr.search(query, **search_options)
 
-    facets = {facet:array_to_dict(v) for facet,v in response.facets['facet_fields'].items()}
+    facets = {facet:list_to_pairs(v) for facet,v in response.facets['facet_fields'].items()}
     #classification_facets = array_to_dict(response.facets['facet_fields']['facet_classification'])
     #author_facets = array_to_dict(response.facets['facet_fields']['facet_author'])
     #subject_facets = array_to_dict(response.facets['facet_fields']['facet_subject'])


### PR DESCRIPTION
The python app is mounted under /p/. Need to pass SCRIPT_NAME header
so the python templating will generate correct links. Also need to get
Apache to send the prefix (it was being stripped), and need python app
to not redirect if a slash is missing (this caused an infinite redirect
loop).

Fixed function name error in the flask code.