### PR TITLE
Add basic auth to flask

### DIFF
--- a/config/Dockerfile-web
+++ b/config/Dockerfile-web
@@ -28,6 +28,7 @@ RUN mkdir -p /var/log/httpd \
         /opt/reader/log \
         /opt/reader/pip_cache \
     && chmod -R a+rwx /var/log/httpd /opt/reader/ /opt/reader/log /opt/reader/pip_cache \
+    && chmod -R a+rwx /data-disk/reader-compute/reader-classic/queue/todo/ /data-disk/reader-compute/reader-classic/queue/backlog/ \
     && ln -s /usr/bin/perl /data-disk/bin/perl
 
 # dummy user "test", password "test"

--- a/config/httpd-le-ssl.conf
+++ b/config/httpd-le-ssl.conf
@@ -6,11 +6,6 @@
 	DirectoryIndex index.html index.htm index.shtml index.cgi
 	ErrorDocument 401 /etc/401.html
 	<Location "/p">
-		AuthType Basic
-		AuthName "Authentication Required"
-		AuthUserFile "/data-disk/etc/reader-htpasswd"
-		Require valid-user
-
 		RequestHeader set SCRIPT_NAME "/p/"
 		ProxyPass "http://localhost:8000/p/"
 		ProxyPassReverse "http://localhost:8000/"

--- a/config/httpd.conf
+++ b/config/httpd.conf
@@ -377,11 +377,6 @@ HostnameLookups on
 	ErrorDocument 401 /etc/401.html
 
 	<Location "/p">
-		AuthType Basic
-		AuthName "Authentication Required"
-		AuthUserFile "/data-disk/etc/reader-htpasswd"
-		Require valid-user
-
 		RequestHeader set SCRIPT_NAME "/p/"
 		ProxyPass "http://localhost:8000/p/"
 		ProxyPassReverse "http://localhost:8000/"

--- a/config/webui-config.docker
+++ b/config/webui-config.docker
@@ -1,5 +1,6 @@
 # configure for local laptop
 APPLICATION_ROOT='/p/'
+HTPASSWD_FILE='/data-disk/etc/reader-htpasswd'
 
 TODO_PATH = '/data-disk/reader-compute/reader-classic/queue/todo'
 BACKLOG_PATH = '/data-disk/reader-compute/reader-classic/queue/backlog'

--- a/webui/Pipfile
+++ b/webui/Pipfile
@@ -7,6 +7,8 @@ name = "pypi"
 flask = "*"
 gunicorn = "*"
 pysolr = "*"
+flask-httpauth = "*"
+passlib = "*"
 
 [dev-packages]
 

--- a/webui/Pipfile.lock
+++ b/webui/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c1632049d618de85a4e672c10a59e54469871a5544b45303b70dbea777bfa352"
+            "sha256": "ddbdf307916f14a36d1873900b72037b0e6bca54d7ad8ef4e2f089e58e755aa6"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -46,6 +46,14 @@
             ],
             "index": "pypi",
             "version": "==1.1.2"
+        },
+        "flask-httpauth": {
+            "hashes": [
+                "sha256:3fcedb99a03985915335a38c35bfee6765cbd66d7f46440fa3b42ae94a90fac7",
+                "sha256:8c7e49e53ce7dc14e66fe39b9334e4b7ceb8d0b99a6ba1c3562bb528ef9da84a"
+            ],
+            "index": "pypi",
+            "version": "==4.2.0"
         },
         "gunicorn": {
             "hashes": [
@@ -136,6 +144,14 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.1.1"
+        },
+        "passlib": {
+            "hashes": [
+                "sha256:aa6bca462b8d8bda89c70b382f0c298a20b5560af6cbfa2dce410c0a2fb669f1",
+                "sha256:defd50f72b65c5402ab2c573830a6978e5f202ad0d984793c8dde2c4152ebe04"
+            ],
+            "index": "pypi",
+            "version": "==1.7.4"
         },
         "pysolr": {
             "hashes": [

--- a/webui/config.local
+++ b/webui/config.local
@@ -3,6 +3,7 @@
 SECRET_KEY='replace in production'
 TESTING=True  # false in production
 APPLICATION_ROOT='/'   # or '/p/'?
+HTPASSWD_FILE='../config/dummy-htpasswd'
 
 TODO_PATH = 'queue/todo'
 BACKLOG_PATH = 'queue/backlog'


### PR DESCRIPTION
It will use the existing apache password file for the users/passwords.
All the submission routes are protected, the general CORD and Gutenberg
search pages are not. The username for carrel submission is pulled from
the auth headers.