### PR TITLE
Add flask-login for user management

### DIFF
--- a/config/httpd-le-ssl.conf
+++ b/config/httpd-le-ssl.conf
@@ -8,7 +8,7 @@
 	<Location "/p">
 		RequestHeader set SCRIPT_NAME "/p"
 		ProxyPass "http://localhost:8000/p"
-		ProxyPassReverse "http://localhost:8000/"
+		#ProxyPassReverse "http://localhost:8000/"
 	</Location>
 	<Directory "/data-disk/www/html/reader">
 		Options All

--- a/config/httpd.conf
+++ b/config/httpd.conf
@@ -379,7 +379,7 @@ HostnameLookups on
 	<Location "/p">
 		RequestHeader set SCRIPT_NAME "/p"
 		ProxyPass "http://localhost:8000/p"
-		ProxyPassReverse "http://localhost:8000/"
+		#ProxyPassReverse "http://localhost:8000/"
 	</Location>
 
 	<Directory "/data-disk/www/html/reader">

--- a/config/runit/reader/run
+++ b/config/runit/reader/run
@@ -4,4 +4,4 @@ export PIPENV_CACHE_DIR=/opt/reader/pip_cache
 export WORKON_HOME=/opt/reader/pip_cache
 exec 2>&1
 cd /opt/reader
-exec chpst -u app -e /opt/reader/env pipenv run gunicorn --access-logfile - hello:app
+exec chpst -u app -e /opt/reader/env pipenv run gunicorn --access-logfile - main:app

--- a/config/webui-config.docker
+++ b/config/webui-config.docker
@@ -1,6 +1,7 @@
 # configure for local laptop
 APPLICATION_ROOT='/p/'
 HTPASSWD_FILE='/data-disk/etc/reader-htpasswd'
+SECRET_KEY= b'\xab\x9e>\xcb\xd2\x04H\x08\x8f\xdc\xc9\xb4\xdfIu\xc0'
 
 TODO_PATH = '/data-disk/reader-compute/reader-classic/queue/todo'
 BACKLOG_PATH = '/data-disk/reader-compute/reader-classic/queue/backlog'

--- a/webui/Pipfile
+++ b/webui/Pipfile
@@ -9,6 +9,10 @@ gunicorn = "*"
 pysolr = "*"
 flask-httpauth = "*"
 passlib = "*"
+oauthlib = "*"
+flask-login = "*"
+requests = "*"
+is-safe-url = "*"
 
 [dev-packages]
 

--- a/webui/Pipfile.lock
+++ b/webui/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ddbdf307916f14a36d1873900b72037b0e6bca54d7ad8ef4e2f089e58e755aa6"
+            "sha256": "fe207a199d2368a2ae2ff012bca565a786afd24c9550b8c91e7d67dce2549e0a"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -55,6 +55,14 @@
             "index": "pypi",
             "version": "==4.2.0"
         },
+        "flask-login": {
+            "hashes": [
+                "sha256:6d33aef15b5bcead780acc339464aae8a6e28f13c90d8b1cf9de8b549d1c0b4b",
+                "sha256:7451b5001e17837ba58945aead261ba425fdf7b4f0448777e597ddab39f4fba0"
+            ],
+            "index": "pypi",
+            "version": "==0.5.0"
+        },
         "gunicorn": {
             "hashes": [
                 "sha256:1904bb2b8a43658807108d59c3f3d56c2b6121a701161de0ddf9ad140073c626",
@@ -70,6 +78,14 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.10"
+        },
+        "is-safe-url": {
+            "hashes": [
+                "sha256:0d55e554974039deec7f9a395aab1e488abac811006d17f930607c43e6d3948e",
+                "sha256:d776186f6877211daefde6a18da1df520de985a582b293e7aa24ea1df1cd5abb"
+            ],
+            "index": "pypi",
+            "version": "==1.0"
         },
         "itsdangerous": {
             "hashes": [
@@ -145,6 +161,14 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.1.1"
         },
+        "oauthlib": {
+            "hashes": [
+                "sha256:bee41cc35fcca6e988463cacc3bcb8a96224f470ca547e697b604cc697b2f889",
+                "sha256:df884cd6cbe20e32633f1db1072e9356f53638e4361bef4e8b03c9127c9328ea"
+            ],
+            "index": "pypi",
+            "version": "==3.1.0"
+        },
         "passlib": {
             "hashes": [
                 "sha256:aa6bca462b8d8bda89c70b382f0c298a20b5560af6cbfa2dce410c0a2fb669f1",
@@ -165,16 +189,16 @@
                 "sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804",
                 "sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "index": "pypi",
             "version": "==2.25.1"
         },
         "urllib3": {
             "hashes": [
-                "sha256:1b465e494e3e0d8939b50680403e3aedaa2bc434b7d5af64dfd3c958d7f5ae80",
-                "sha256:de3eedaad74a2683334e282005cd8d7f22f4d55fa690a2a1020a416cb0a47e73"
+                "sha256:2f4da4594db7e1e110a944bb1b551fdf4e6c136ad42e4234131391e21eb5b0df",
+                "sha256:e7b021f7241115872f92f43c6508082facffbd1c048e3c6e2bb9c2a157e28937"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
-            "version": "==1.26.3"
+            "version": "==1.26.4"
         },
         "werkzeug": {
             "hashes": [

--- a/webui/app.py
+++ b/webui/app.py
@@ -1,0 +1,19 @@
+from flask import (Flask, session, render_template, request, g)
+
+app = Flask(__name__)
+app.config.from_envvar('READER_CONFIG')
+app.url_map.strict_slashes = False
+
+app.config['USE_SESSION_FOR_NEXT'] = 1
+
+##### Template helpers
+
+NUMERALS = {1:'I', 2:'II', 3:'III', 4:'IV', 5:'V',
+        6:'VI', 7:'VII', 8:'VIII', 9:'IX', 10:'X',
+        11:'XI', 12:'XII', 13:'XIII', 14:'XIV', 15:'XV',
+        16:'XVI', 17:'XVII', 18:'XVIII', 19:'XIX', 20:'XX'}
+
+@app.template_filter('roman_numeral')
+def roman_numeral(n):
+    return NUMERALS.get(n, '')
+

--- a/webui/auth.py
+++ b/webui/auth.py
@@ -1,0 +1,32 @@
+from app import app
+from flask_login import LoginManager
+from passlib.apache import HtpasswdFile
+from models import User
+
+
+login_manager = LoginManager()
+login_manager.init_app(app)
+
+@login_manager.user_loader
+def load_user(user_id):
+    # for now user_id is just the username
+    if user_id is not None and user_id != "":
+        return User(user_id)
+    return None
+
+login_manager.login_view = "login"
+
+# set up auth to use existing apache user file
+htpasswd = None
+htpasswd_filename = app.config.get('HTPASSWD_FILE', None)
+if htpasswd_filename:
+    htpasswd = HtpasswdFile(htpasswd_filename)
+
+def verify_password(username, password):
+    if htpasswd:
+        return htpasswd.check_password(username, password)
+    # only allow no password file if in debugging mode.
+    # this is to "fail-safe" in production
+    # if we are not in debug mode, every auth request fails
+    return app.debug
+

--- a/webui/main.py
+++ b/webui/main.py
@@ -1,0 +1,8 @@
+from app import app
+
+from auth import *
+#from models import *
+from views import *
+
+if __name__ == '__main__':
+    app.run()

--- a/webui/models.py
+++ b/webui/models.py
@@ -1,0 +1,6 @@
+from flask_login import UserMixin
+
+class User(UserMixin):
+    def __init__(self, userid):
+        self.id = userid
+

--- a/webui/templates/login.html
+++ b/webui/templates/login.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Login</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<style>
+		body { font-family: Georgia, serif; }
+		h1,h2 {font-family: Verdana, sans-serif}
+		ol.whatshere li {margin-top: 1em}
+	</style>
+</head>
+<body style="margin-left: 3%; margin-right:3%; margin-top: 3%; margin-bottom: 3%">
+<h1 style='text-align:center'>Login</h1>
+
+<form method="post" action="{{ url_for('login') }}">
+    <label>User name: <input type='text' name="username" /></label>
+    <label>Password: <input type='password' name="password" /></label>
+    <button type='submit'>Submit</button>
+</form>
+</body>
+</html>

--- a/webui/views.py
+++ b/webui/views.py
@@ -1,48 +1,35 @@
-from flask import (Flask,render_template, request)
+from flask import (render_template, session, request, redirect, g, url_for)
 from werkzeug.utils import secure_filename
 from datetime import datetime
-from flask_httpauth import HTTPBasicAuth
-from passlib.apache import HtpasswdFile
 import os.path
 import pysolr
+from app import app
+from models import User
+from flask_login import login_user, login_required, current_user
+from auth import login_manager, verify_password
+from is_safe_url import is_safe_url
 
-app = Flask(__name__)
-app.config.from_envvar('READER_CONFIG')
-app.url_map.strict_slashes = False
-
-auth = HTTPBasicAuth(realm="Authentication Required")
-
-htpasswd = None
-htpasswd_filename = app.config.get('HTPASSWD_FILE', None)
-if htpasswd_filename:
-    htpasswd = HtpasswdFile(htpasswd_filename)
-
-@auth.verify_password
-def verify_password(username, password):
-    if htpasswd:
-        return htpasswd.check_password(username, password)
-    # only allow no password file if in debugging mode.
-    # this is to "fail-safe" in production
-    # if we are not in debug mode, every auth request fails
-    return app.debug
-
-##### Template helpers
-
-NUMERALS = {1:'I', 2:'II', 3:'III', 4:'IV', 5:'V',
-        6:'VI', 7:'VII', 8:'VIII', 9:'IX', 10:'X',
-        11:'XI', 12:'XII', 13:'XIII', 14:'XIV', 15:'XV',
-        16:'XVI', 17:'XVII', 18:'XVIII', 19:'XIX', 20:'XX'}
-
-@app.template_filter('roman_numeral')
-def roman_numeral(n):
-    return NUMERALS.get(n, '')
-
-
-##### Route Handlers
 
 @app.route('/')
 def index():
     return render_template('home.html')
+
+@app.route('/login', methods=['GET', 'POST'])
+def login():
+    if request.method == 'POST':
+        username = request.form.get('username', '')
+        password = request.form.get('password', '')
+        if verify_password(username, password):
+            u = User(username)
+            login_user(u)
+            next = session.pop('next', url_for('index'))
+            if is_safe_url(next, allowed_hosts=None):
+                return redirect(next)
+    return render_template('login.html')
+
+@app.route('/login/callback', methods=['GET', 'POST'])
+def login_callback():
+    pass
 
 def add_job_to_queue(job_type, shortname, username, extra):
     now = datetime.now().strftime("%Y-%m-%d\t%H:%M")
@@ -53,12 +40,12 @@ def add_job_to_queue(job_type, shortname, username, extra):
         f.write("\n")
 
 @app.route('/create/url2carrel', methods=['GET', 'POST'])
-@auth.login_required
+@login_required
 def url2carrel():
     TYPE = 'url2carrel'
     shortname = request.form.get('shortname', '')
     target_url = request.form.get('url', '')
-    username = auth.username()
+    username = current_user.id
 
     if request.method != 'POST' or shortname == '' or target_url == '':
         return render_template('url2carrel.html')
@@ -67,14 +54,14 @@ def url2carrel():
     return render_template('urls2carrel-queue.html', username=username, shortname=shortname)
 
 @app.route('/create/urls2carrel', methods=['GET', 'POST'])
-@auth.login_required
+@login_required
 def urls2carrel():
     TYPE = 'urls2carrel'
 
     # initialize
     shortname  = request.form.get('shortname', '')
     queue = request.form.get('queue', '')
-    username = auth.username()
+    username = current_user.id
 
     if request.method != 'POST' or shortname == '':
         return render_template('urls2carrel.html')
@@ -89,14 +76,14 @@ def urls2carrel():
 
 
 @app.route('/create/zip2carrel', methods=['GET', 'POST'])
-@auth.login_required
+@login_required
 def zip2carrel():
     TYPE = 'zip2carrel'
 
     # initialize
     shortname = request.form.get('shortname', '')
     queue = request.form.get('queue', '')
-    username = auth.username()
+    username = current_user.id
 
     if request.method != 'POST' or shortname == '':
         return render_template('zip2carrel.html')
@@ -110,13 +97,13 @@ def zip2carrel():
     return render_template('zip2carrel-queue.html', username=username, shortname=shortname)
 
 @app.route('/create/file2carrel', methods=['GET', 'POST'])
-@auth.login_required
+@login_required
 def file2carrel():
     TYPE = 'file2carrel'
 
     shortname = request.form.get('shortname', '')
     queue = request.form.get('queue', '')
-    username = auth.username()
+    username = current_user.id
 
     if request.method != 'POST' or shortname == '':
         return render_template('file2carrel.html')
@@ -130,14 +117,14 @@ def file2carrel():
     return render_template('file2carrel-queue.html', username=username, shortname=shortname)
 
 @app.route('/create/trust2carrel', methods=['GET', 'POST'])
-@auth.login_required
+@login_required
 def trust2carrel():
     TYPE = 'trust'
 
     # initialize
     shortname = request.form.get('shortname', '')
     queue = request.form.get('queue', '')
-    username = auth.username()
+    username = current_user.id
 
     if request.method != 'POST' or shortname == '':
         return render_template('trust2carrel.html')
@@ -151,13 +138,13 @@ def trust2carrel():
     return render_template('trust2carrel-queue.html', username=username, shortname=shortname)
 
 @app.route('/create/biorxiv2carrel', methods=['GET', 'POST'])
-@auth.login_required
+@login_required
 def biorxiv2carrel():
     TYPE = 'biorxiv'
 
     shortname = request.form.get('shortname', '')
     queue = request.form.get('queue', '')
-    username = auth.username()
+    username = current_user.id
 
     if request.method != 'POST' or shortname == '':
         return render_template('biorxiv2carrel.html')
@@ -222,7 +209,7 @@ def gutenberg():
             facets=facets)
 
 @app.route('/create/gutenberg', methods=['GET', 'POST'])
-@auth.login_required
+@login_required
 def create_gutenberg():
     TYPE = 'gutenberg'
 
@@ -230,7 +217,7 @@ def create_gutenberg():
     # query is passed as a param for GET requests and as
     # as a form vaule for POSTs.
     shortname = request.form.get('shortname', '')
-    username = auth.username()
+    username = current_user.id
 
     if request.method != 'POST' or shortname == '':
         query = request.args.get('query', '')
@@ -278,7 +265,7 @@ def cord_search():
             facets=facets)
 
 @app.route('/create/cord', methods=['GET', 'POST'])
-@auth.login_required
+@login_required
 def create_cord():
     TYPE = 'cord'
 
@@ -286,7 +273,7 @@ def create_cord():
     # query is passed as a param for GET requests and as
     # as a form vaule for POSTs.
     shortname = request.form.get('shortname', '')
-    username = auth.username()
+    username = current_user.id
 
     if request.method != 'POST' or shortname == '':
         query = request.args.get('query', '')
@@ -296,4 +283,5 @@ def create_cord():
     shortname = secure_filename(shortname)
     add_job_to_queue(TYPE, shortname, username, query)
     return render_template('cord-queue.html', username=username, shortname=shortname)
+
 


### PR DESCRIPTION
This stores the user login info in a session cookie instead of having
the browser sent authoriztion headers. It still uses the Apache htaccess
file as the password database.

Using the session cookie to identify a log-in is on the path to adding
an oauth login.

Also remove the Apache rewriting of the paths. The flask script knows it
is run under a path-prefix, and apache was then rewriting the redirects
to add the path prefix a second time.