### PR TITLE
Add private carrel list display

### DIFF
--- a/lib/scan_private_carrels.sh
+++ b/lib/scan_private_carrels.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+#
+# scan_private_carrels.sh <start directory>
+#
+# A study carrel is a directory that has a file named "provenance.tsv" in it.
+# Any found study carrels are entered into the database (if they aren't there
+# already).
+#
+# n.b. study carrels cannot be nested.
+
+DATABASE_FILE="/data-disk/etc/reader-patrons.db"
+
+
+find $1 -type f -name "provenance.tsv" | while read provenance; do
+    CARREL=$(dirname $(realpath $provenance))
+    SHORTNAME=$( basename $CARREL )
+    ITEMS=$( echo "SELECT COUNT( id ) FROM bib;" | sqlite3 "$CARREL/etc/reader.db" )
+    WORDS=$( echo "SELECT SUM( words ) FROM bib;" | sqlite3 "$CARREL/etc/reader.db" )
+    FLESCH=$( echo "SELECT RTRIM( ROUND( AVG( flesch ) ), '.0' ) FROM bib;" | sqlite3 "$CARREL/etc/reader.db" )
+    SIZE=$( du "$CARREL/study-carrel.zip" | cut -f1 )
+    DATE=$( awk '{print $3}' $CARREL/provenance.tsv )
+    OWNER=$( awk '{print $5}' $CARREL/provenance.tsv )
+
+    # Supply defaults since these are missing on a few carrels
+    if [ -z $ITEMS ]; then
+        ITEMS=0
+    fi
+    if [ -z $WORDS ]; then
+        WORDS=0
+    fi
+    if [ -z $FLESCH ]; then
+        FLESCH=0
+    fi
+    if [ -z $SIZE ]; then
+        SIZE=0
+    fi
+
+    sqlite3 $DATABASE_FILE <<EOF
+INSERT OR REPLACE INTO carrels
+(owner, shortname, fullpath, status, created, items, words, readability, bytes)
+VALUES ("$OWNER",
+        "$SHORTNAME",
+        "$CARREL",
+        "private",
+        "$DATE",
+        $ITEMS,
+        $WORDS,
+        $FLESCH,
+        $SIZE);
+EOF
+
+done

--- a/webui/README.md
+++ b/webui/README.md
@@ -1,0 +1,21 @@
+WebUI
+=====
+
+This directory is the source for the web front end for the Distant Reader. It is implemented as
+a Python Flask application.
+
+
+## How-Tos
+
+### Run the app locally
+
+```
+pipenv shell
+env READER_CONFIG=config.local FLASK_ENV=development FLASK_APP=main.py flask run
+```
+
+### Create a database migration
+
+```
+yoyo new ./migrations --sql -m "Add carrel table"
+```

--- a/webui/app.py
+++ b/webui/app.py
@@ -11,6 +11,17 @@ app.config["USE_SESSION_FOR_NEXT"] = 1
 
 ##### Template helpers
 
+@app.template_filter("formatwithcommas")
+def formatwithcommas(n):
+    try:
+        return "{:,}".format(int(n))
+    except:
+        return n
+
+    for fragment, desc in DESCRIPTIONS.items():
+        if filepath.endswith(fragment):
+            return desc
+    return ""
 NUMERALS = {
     1: "I",
     2: "II",
@@ -38,3 +49,100 @@ NUMERALS = {
 @app.template_filter("roman_numeral")
 def roman_numeral(n):
     return NUMERALS.get(n, "")
+
+
+DESCRIPTIONS = {
+    # study carrel root
+    "index.html": "Narrative report; <span style='color: darkred;text-decoration: underline'><strong>read this second</strong></span>",
+    "cache": 'Original versions of analyzed files; file name roots are used as "keys" throughout the carrel',
+    "pos": "Part-of-speech file(s); importable into your spreadsheet, database, or analysis application",
+    "standard-output.txt": "Simple narrative report; <span style='color: darkred;text-decoration: underline'><strong>start here</strong></span>",
+    "standard-error.txt": "Log file; if this carrel is dysfunctional, then send this file to Eric Morgan &lt;emorgan@nd.edu&gt;",
+    "study-carrel.zip": "Study carrel as a single file; download this file for offline reading and more thorough use &amp; understanding",
+    "provenance.tsv": "A record of who created this carrel, when, and how",
+    "MANIFEST.htm": "Description of all the files in a study carrel; a verbose version of this page; <span style='color: darkred;text-decoration: underline'><strong>read this third</strong></span>",
+    "adr": "Email address file(s); importable into your spreadsheet, database, or analysis application",
+    "etc": "Database file, stop words file, etc; power-users will love these files",
+    "figures": "Charts &amp; graphs used in the narrative report",
+    "LICENSE": "GNU Public License",
+    # figures
+    "sizes-histogram.png": "Histogram of <strong>document sizes</strong>",
+    "sizes-boxplot.png": "Box plot of <strong>document sizes</strong>",
+    "topics.png": 'Pie chart of topic modeling <strong>"themes"</strong>',
+    "unigrams.png": "Word cloud of most <strong>words</strong>",
+    "proper-nouns.png": "Word cloud of most frequent <strong>proper nouns</strong>",
+    "pronouns.png": "Word cloud of most frequent <strong>pronouns</strong>",
+    "nouns.png": "Word cloud of most frequent <strong>nouns</strong>",
+    "keywords.png": "Word cloud of most frequent <strong>keywords</strong>",
+    "adjectives.png": "Word cloud of most frequent <strong>adjectives</strong>",
+    "adverbs.png": "Word cloud of most frequent <strong>adverbs</strong>",
+    "bigrams.png": "Word cloud of most frequent <strong>two-word phrases</strong>",
+    "flesch-boxplot.png": "Box plot of <strong>readability scores</strong>",
+    "flesch-histogram.png": "Histogram of <strong>readability scores</strong>",
+    "verbs.png": "Word cloud of most frequent <strong>verbs</strong>",
+    # sub reports
+    "adverbs.htm": "HTML table of most frequent <strong>adverbs</strong>",
+    "verbs.htm": "HTML table of most frequent <strong>verbs</strong>",
+    "adjective-noun.htm": "HTML table of most frequent <strong>adjective-noun combinations</strong>",
+    "noun-verb.htm": "HTML table of most frequent <strong>noun-verb combinations</strong>",
+    "adjectives.htm": "HTML table of most frequent <strong>adjectives</strong>",
+    "proper-nouns.htm": "HTML table of most frequent <strong>proper nouns<strong>",
+    "pronouns.htm": "HTML table of most frequent <strong>pronouns</strong>",
+    "nouns.htm": "HTML table of most frequent <strong>nouns</strong>",
+    "keywords.htm": "HTML table of most frequent <strong>keywords</strong>",
+    "bigrams.htm": "HTML table of most frequent <strong>two-word phrases</strong>",
+    "quadgrams.htm": "HTML table of most frequent <strong>four-word phrases</strong>",
+    "questions.htm": "HTML table of <strong>questions</strong>",
+    "search.htm": "Rudimentary <strong>search interface</strong>",
+    "topic-model.htm": "Rudimentary <strong>topic modeling interface</strong>",
+    "unigrams.htm": "HTML table of most frequent <strong>words</strong>",
+    "trigrams.htm": "HTML table of most frequent <strong>three-word phrases</strong>",
+    "entities.htm": "HTML table of most frequent <strong>named-entities and their types</strong>",
+    "bibliographics.htm": 'HTML table of bibliographics; a rudimentary <strong>"library catalog"<strong>',
+    "adverbs.tsv": "TSV file of most frequent <strong>adverbs</strong> and their counts",
+    "verbs.tsv": "TSV file of most frequent <strong>verbs</strong> and their counts",
+    "adjective-noun.tsv": "TSV file of most frequent <strong>adjective-noun combinations</strong> and their counts",
+    "noun-verb.tsv": "TSV file of most frequent <strong>noun-verb combinations</strong> and their counts",
+    "adjectives.tsv": "TSV file of most frequent <strong>adjectives</strong> and their counts",
+    "proper-nouns.tsv": "TSV file of most frequent <strong>proper nouns</strong> and their counts",
+    "pronouns.tsv": "TSV file of most frequent <strong>pronouns</strong> and their counts",
+    "nouns.tsv": "TSV file of most frequent <strong>nouns</strong> and their counts",
+    "keywords.tsv": "TSV filee of most frequent <strong>keywords</strong> and their counts",
+    "bigrams.tsv": "TSV filee of most frequent <strong>two-word phrases</strong> and their counts",
+    "quadgrams.tsv": "TSV file of most frequent <strong>four-word phrases</strong> and their counts",
+    "questions.tsv": "TSV file of <strong>questions</strong>",
+    "unigrams.tsv": "TSV file of most frequent <strong>words</strong> and their counts",
+    "trigrams.tsv": "TSV file of most frequent <strong>three-word phrases</strong> and their counts",
+    "entities.tsv": "TSV file of most frequent <strong>named-entities and their types</strong> and their counts",
+    "bibliographics.tsv": 'TSV file of bibliographics; a rudimentary <strong>"library catalog"</strong>',
+    # etc
+    "model-data.txt": "Data file used by topic modeling interface",
+    "queries.sql": "SQL statements used to create the simple narrative report; great for learning how to query reader.db",
+    "reader.db": "Cross-platform SQLite database file; the answers to your research questions are probably in here",
+    "reader.sql": "SQL statements denoting the structure of reader.db; great for learning about reader.db",
+    "reader.txt": "A concatenation of all plain text files used for analysis; the entire corpus in a single file ",
+    "report.txt": "A copy of the simple narrative report",
+    "stopwords.txt": 'A list of "function" words excluded from analysis',
+    "reader.zip": "Study carrel as a single file; download this file for offline reading and more thorough use &amp; understanding",
+    # defaults,
+    "txt": 'Plain text version(s) of cached file(s); file(s) used for "distant reading" purposes',
+    "tsv": "Tab-delimited (TSV) files used in narrative report",
+    "ent": "Name-entity file(s); TSV file(s) importable into your spreadsheet, database, or analysis application",
+    "bib": "Bibliographic file(s); TSV file(s) importable into your spreadsheet, database, or analysis application",
+    "pdf": "Portable Document File; a file usually designed for printing",
+    "html": "HTML file readable with your Web browser",
+    "htm": "Sub-reports of the narrative report",
+    "docx": "A Microsoft Word document",
+    "css": "Cascading stylesheet file(s) for use by the narrative report",
+    "js": "Javascript file(s) used by the narrative report",
+    "urls": "URL file(s); importable into your spreadsheet, database, or analysis application",
+    "wrd": "Keyword file(s); TSV file(s) importable into your spreadsheet, database, or analysis application",
+}
+
+
+@app.template_filter("file_description")
+def file_description(filepath):
+    for fragment, desc in DESCRIPTIONS.items():
+        if filepath.endswith(fragment):
+            return desc
+    return ""

--- a/webui/descriptions.txt
+++ b/webui/descriptions.txt
@@ -1,0 +1,112 @@
+
+# /data-disk/www/html/library/.htaccess - configure auto indexing for the Distant Reader
+
+# Eric Lease Morgan <emorgan@nd.edu>
+# (c) University of Notre Dame; distributed under a GNU Public License
+
+# December 26, 2020 - first investigations
+
+
+# general configurations
+DirectoryIndex index.html
+IndexOptions DescriptionWidth=* NameWidth=* FancyIndexing HTMLTable IgnoreCase IconsAreLinks 
+ReadmeName /includes/footer.html
+AddType text/plain .sql
+
+# icons
+AddIcon /icons/layout.png .htm .pdf .docx .doc .html
+AddIcon /icons/script.png .sql .css .js
+AddIcon /icons/binary.png .db
+AddIcon /icons/text.gif .txt .wrd .pos .adr .url
+
+# study carrel root
+AddDescription "Narrative report; <span style='color: darkred;text-decoration: underline'><strong>read this second</strong></span>" index.htm
+AddDescription 'Original versions of analyzed files; file name roots are used as "keys" throughout the carrel' cache
+AddDescription "Part-of-speech file(s); importable into your spreadsheet, database, or analysis application" pos
+AddDescription "Simple narrative report; <span style='color: darkred;text-decoration: underline'><strong>start here</strong></span>" "standard-output.txt"
+AddDescription "Log file; if this carrel is dysfunctional, then send this file to Eric Morgan &lt;emorgan@nd.edu&gt;" "standard-error.txt"
+AddDescription "Study carrel as a single file; download this file for offline reading and more thorough use &amp; understanding" study-carrel.zip
+AddDescription "A record of who created this carrel, when, and how" "provenance.tsv"
+AddDescription "Description of all the files in a study carrel; a verbose version of this page; <span style='color: darkred;text-decoration: underline'><strong>read this third</strong></span>" "MANIFEST.htm"
+AddDescription "Email address file(s); importable into your spreadsheet, database, or analysis application" adr
+AddDescription "Database file, stop words file, etc; power-users will love these files" etc
+AddDescription "Charts &amp; graphs used in the narrative report" figures
+AddDescription "GNU Public License" LICENSE
+
+# figures
+AddDescription 'Histogram of <strong>document sizes</strong>' "sizes-histogram.png"
+AddDescription 'Box plot of <strong>document sizes</strong>' "sizes-boxplot.png"
+AddDescription 'Pie chart of topic modeling <strong>"themes"</strong>' "topics.png"
+AddDescription "Word cloud of most <strong>words</strong>" "unigrams.png"
+AddDescription "Word cloud of most frequent <strong>proper nouns</strong>" "proper-nouns.png"
+AddDescription "Word cloud of most frequent <strong>pronouns</strong>" "pronouns.png"
+AddDescription "Word cloud of most frequent <strong>nouns</strong>" "nouns.png"
+AddDescription "Word cloud of most frequent <strong>keywords</strong>" "keywords.png"
+AddDescription "Word cloud of most frequent <strong>adjectives</strong>" "adjectives.png"
+AddDescription "Word cloud of most frequent <strong>adverbs</strong>" "adverbs.png"
+AddDescription "Word cloud of most frequent <strong>two-word phrases</strong>" "bigrams.png"
+AddDescription "Box plot of <strong>readability scores</strong>" "flesch-boxplot.png"
+AddDescription "Histogram of <strong>readability scores</strong>" "flesch-histogram.png"
+AddDescription "Word cloud of most frequent <strong>verbs</strong>" "verbs.png"
+
+# sub reports
+AddDescription "HTML table of most frequent <strong>adverbs</strong>" "adverbs.htm"
+AddDescription "HTML table of most frequent <strong>verbs</strong>" "verbs.htm"
+AddDescription "HTML table of most frequent <strong>adjective-noun combinations</strong>" "adjective-noun.htm"
+AddDescription "HTML table of most frequent <strong>noun-verb combinations</strong>" "noun-verb.htm"
+AddDescription "HTML table of most frequent <strong>adjectives</strong>" "adjectives.htm"
+AddDescription "HTML table of most frequent <strong>proper nouns<strong>" "proper-nouns.htm"
+AddDescription "HTML table of most frequent <strong>pronouns</strong>" "pronouns.htm"
+AddDescription "HTML table of most frequent <strong>nouns</strong>" "nouns.htm"
+AddDescription "HTML table of most frequent <strong>keywords</strong>" "keywords.htm"
+AddDescription "HTML table of most frequent <strong>two-word phrases</strong>" "bigrams.htm"
+AddDescription "HTML table of most frequent <strong>four-word phrases</strong>" "quadgrams.htm"
+AddDescription "HTML table of <strong>questions</strong>" "questions.htm"
+AddDescription "Rudimentary <strong>search interface</strong>" "search.htm"
+AddDescription "Rudimentary <strong>topic modeling interface</strong>" "topic-model.htm"
+AddDescription "HTML table of most frequent <strong>words</strong>" "unigrams.htm"
+AddDescription "HTML table of most frequent <strong>three-word phrases</strong>" "trigrams.htm"
+AddDescription "HTML table of most frequent <strong>named-entities and their types</strong>" "entities.htm"
+AddDescription 'HTML table of bibliographics; a rudimentary <strong>"library catalog"<strong>' "bibliographics.htm"
+
+AddDescription "TSV file of most frequent <strong>adverbs</strong> and their counts" "adverbs.tsv"
+AddDescription "TSV file of most frequent <strong>verbs</strong> and their counts" "verbs.tsv"
+AddDescription "TSV file of most frequent <strong>adjective-noun combinations</strong> and their counts" "adjective-noun.tsv"
+AddDescription "TSV file of most frequent <strong>noun-verb combinations</strong> and their counts" "noun-verb.tsv"
+AddDescription "TSV file of most frequent <strong>adjectives</strong> and their counts" "adjectives.tsv"
+AddDescription "TSV file of most frequent <strong>proper nouns</strong> and their counts" "proper-nouns.tsv"
+AddDescription "TSV file of most frequent <strong>pronouns</strong> and their counts" "pronouns.tsv"
+AddDescription "TSV file of most frequent <strong>nouns</strong> and their counts" "nouns.tsv"
+AddDescription "TSV filee of most frequent <strong>keywords</strong> and their counts" "keywords.tsv"
+AddDescription "TSV filee of most frequent <strong>two-word phrases</strong> and their counts" "bigrams.tsv"
+AddDescription "TSV file of most frequent <strong>four-word phrases</strong> and their counts" "quadgrams.tsv"
+AddDescription "TSV file of <strong>questions</strong>" "questions.tsv"
+AddDescription "TSV file of most frequent <strong>words</strong> and their counts" "unigrams.tsv"
+AddDescription "TSV file of most frequent <strong>three-word phrases</strong> and their counts" "trigrams.tsv"
+AddDescription "TSV file of most frequent <strong>named-entities and their types</strong> and their counts" "entities.tsv"
+AddDescription 'TSV file of bibliographics; a rudimentary <strong>"library catalog"</strong>' "bibliographics.tsv"
+
+# etc
+AddDescription 'Data file used by topic modeling interface' "model-data.txt"
+AddDescription 'SQL statements used to create the simple narrative report; great for learning how to query reader.db' "queries.sql"
+AddDescription 'Cross-platform SQLite database file; the answers to your research questions are probably in here' "reader.db"
+AddDescription 'SQL statements denoting the structure of reader.db; great for learning about reader.db' "reader.sql"
+AddDescription 'A concatenation of all plain text files used for analysis; the entire corpus in a single file ' "reader.txt"
+AddDescription 'A copy of the simple narrative report' "report.txt"
+AddDescription 'A list of "function" words excluded from analysis' "stopwords.txt"
+AddDescription "Study carrel as a single file; download this file for offline reading and more thorough use &amp; understanding" reader.zip
+
+# defaults
+AddDescription 'Plain text version(s) of cached file(s); file(s) used for "distant reading" purposes' txt
+AddDescription "Tab-delimited (TSV) files used in narrative report" tsv
+AddDescription "Name-entity file(s); TSV file(s) importable into your spreadsheet, database, or analysis application" ent
+AddDescription "Bibliographic file(s); TSV file(s) importable into your spreadsheet, database, or analysis application" bib
+AddDescription "Portable Document File; a file usually designed for printing" pdf
+AddDescription "HTML file readable with your Web browser" html
+AddDescription "Sub-reports of the narrative report" htm
+AddDescription "A Microsoft Word document" docx
+AddDescription "Cascading stylesheet file(s) for use by the narrative report" css
+AddDescription "Javascript file(s) used by the narrative report" js
+AddDescription "URL file(s); importable into your spreadsheet, database, or analysis application" urls
+AddDescription "Keyword file(s); TSV file(s) importable into your spreadsheet, database, or analysis application" wrd
+[dbrower@readerHttp library]$ 

--- a/webui/migrations/20210510_01_VWuSb-add-carrel-table.sql
+++ b/webui/migrations/20210510_01_VWuSb-add-carrel-table.sql
@@ -1,0 +1,19 @@
+-- Add carrel table
+-- depends: 20210423_01_m8GP9-add-email-verification
+
+CREATE TABLE if not exists carrels (
+    owner       TEXT,   -- username of who "owns" this carrel
+    shortname   TEXT,   -- the shortname of this carrel
+    fullpath    TEXT,   -- the absolute path to the carrel directory
+    status      TEXT,   -- the status of this carrel
+    created     TEXT,   -- the datetime this carrel was created
+    items       INTEGER,-- the number of source items
+    words       INTEGER,-- the total number of source words
+    readability INTEGER,-- the calculated readability score
+    bytes       INTEGER -- the total number of source bytes
+);
+
+CREATE UNIQUE INDEX i_carrel_owner_name on carrels (owner, shortname);
+CREATE INDEX i_carrel_owner on carrels (owner);
+CREATE INDEX i_carrel_name on carrels (shortname);
+CREATE INDEX i_carrel_status on carrels (status);

--- a/webui/templates/carrel_filelist.html
+++ b/webui/templates/carrel_filelist.html
@@ -1,0 +1,38 @@
+{% extends "base.html" %}
+
+{% block title %}
+Study Carrel {{ carrel.shortname }}
+{% endblock %}
+
+{% block body %}
+<table>
+    <tr>
+        <th><a href="?C=N;O=D">Name</a></th>
+        <th><a href="?C=M;O=A">Last modified</a></th>
+        <th><a href="?C=S;O=A">Size</a></th>
+        <th><a href="?C=D;O=A">Description</a></th>
+    </tr>
+    <tr><th colspan="4"><hr></th></tr>
+    {% if parentdir != '' %}
+    <tr>
+        <td><a href="{{ url_for("patron_carrel", username=current_user.username, carrel=carrel.shortname, p=parentdif) }}">Parent Directory</a></td>
+        <td>&nbsp;</td>
+        <td align="right">  - </td>
+        <td>&nbsp;</td>
+    </tr>
+    {% endif %}
+    {% for entry in listing %}
+    <tr>
+        <td><a href="{{ url_for("patron_carrel", username=current_user.username, carrel=carrel.shortname, p=directory+"/"+entry.filename) }}">{{ entry.filename }}</a></td>
+        <td align="right">{{ entry.modified }}</td>
+        <td align="right">{{ entry.size | filesizeformat }}</td>
+        <td>{{ entry.filename | file_description }}</td>
+    </tr>
+    {% else %}
+    <tr>
+        <td>No Files</td>
+    </tr>
+    {% endfor %}
+</table>
+{% endblock %}
+

--- a/webui/templates/carrel_list.html
+++ b/webui/templates/carrel_list.html
@@ -1,0 +1,61 @@
+{% extends "base.html" %}
+
+{% block title %}
+    Study Carrels for {{ current_user.username }}
+{% endblock %}
+
+{#
+<script type="text/javascript" class="init">
+    $(document).ready(function() { $('#directory').DataTable( {
+        "order": [[ 1, "desc" ]],
+        "pageLength": 100
+    } ); } );
+</script>
+#}
+
+{% block body %}
+<p>Below, select column headings and/or enter words into the search box to sort &amp; filter catalog items. Use the results to read, browse, or download carrels.</p>
+
+<table id="directory" class="display" style="width:100%">
+        <thead>
+            <tr>
+                <th>name</th>
+                <th>created</th>
+                <th>items</th>
+                <th>words</th>
+                <th>readability</th>
+                <th>bytes</th>
+                <th>actions</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for entry in carrels|sort(attribute="shortname") %}
+            <tr>
+                <td>{{ entry.shortname }}</td>
+                <td>{{ entry.created }}</td>
+                <td class='right'>{{ entry.size_items | formatwithcommas }}</td>
+                <td class='right'>{{ entry.size_words | formatwithcommas }}</td>
+                <td  class='right'>{{ entry.readability }}</td>
+                <td class='right'>{{ entry.size_bytes | filesizeformat }}</td>
+                <td class='right'>
+                    <a href='{{ url_for("patron_carrel", username=current_user.username, carrel=entry.shortname, p="index.htm") }}'>read</a>,
+                    <a href='{{ url_for("patron_carrel", username=current_user.username, carrel=entry.shortname) }}'>browse</a>,
+                    <a href='{{ url_for("patron_carrel", username=current_user.username, carrel=entry.shortname, p="study-carrel.zip") }}'>download</a>
+                </td>
+            </tr>
+            {% else %}
+            <tr><td>No Carrels</td></tr>
+            {% endfor %}
+        </tbody>
+    </table>
+
+    {% for entry in listing %}
+    <tr>
+        <td><a href="{{ url_for("patron_carrel", username=current_user.username, carrel=carrel.shortname, p=directory+"/"+entry.filename) }}">{{ entry.filename }}</a></td>
+        <td align="right">{{ entry.modified }}</td>
+        <td align="right">{{ entry.size | filesizeformat }}</td>
+        <td>{{ entry.filename | file_description }}</td>
+    </tr>
+    {% endfor %}
+</table>
+{% endblock %}


### PR DESCRIPTION
The old way used an apache htaccess file. This doesn't work when using
ORCID auth since we store user identity in a cookie. The private carrels
are those in the "patrons/" file tree. This code doesn't do anything
with the public carrels.

* Add carrel table to the database
* Add script to scrape the drive mount and populate the database
* Add page to list all the carrels belonging to a logged-in user
* Add page to list the files in a private carrel
* Allow for the downloading of carrel files