### PR TITLE
Fix downloading files from a private carrel

### DIFF
--- a/webui/templates/carrel_filelist.html
+++ b/webui/templates/carrel_filelist.html
@@ -23,7 +23,7 @@ Study Carrel {{ carrel.shortname }}
     {% endif %}
     {% for entry in listing %}
     <tr>
-        <td><a href="{{ url_for("patron_carrel", username=current_user.username, carrel=carrel.shortname, p=directory+"/"+entry.filename) }}">{{ entry.filename }}</a></td>
+        <td><a href="{{ url_for("patron_carrel", username=current_user.username, carrel=carrel.shortname, p=entry.path) }}">{{ entry.filename }}</a></td>
         <td align="right">{{ entry.modified }}</td>
         <td align="right">{{ entry.size | filesizeformat }}</td>
         <td>{{ entry.filename | file_description }}</td>


### PR DESCRIPTION
Also addresses:
* display last modified time as YYYY-MM-DD
* have better path links for top-level files. There were too many
  slashes being added to them previously.