### PR TITLE
Remove extra query field

### DIFF
--- a/webui/templates/gutenberg.html
+++ b/webui/templates/gutenberg.html
@@ -8,8 +8,6 @@ The Distant Reader - Project Gutenberg to study carrel
     <h4>Gutenberg to Carrel</h4>
     <p>This is selected fulltext index to the content of Project Gutenberg. Enter a query.</p>
       <form method="GET">
-        <input type='hidden' name="query" value='{{ query }}' />
-
         <div class="form-group">
           <label for="shortname">Query</label>
           <input name="query" autofocus="autofocus" class="form-control" size="50" value='{{ query }}'>


### PR DESCRIPTION
Gutenberg search form had two field named "query", and one was hidden.
This kept people from making meaningful searches.