### PR TITLE
Fix cord typo

### DIFF
--- a/webui/templates/cord.html
+++ b/webui/templates/cord.html
@@ -8,7 +8,8 @@ The Distant Reader - COVID-19 literature to study carrel
 <p>Use these pages to search the CORD data set and possibly queue the creation of study carrels.</p>
 <p>Enter a query.</p>
 <form method='GET'>
-  <div class="form-group" <textarea name='query' autofocus="autofocus" cols='50' rows='10'>{{ query }}</textarea>
+  <div class="form-group">
+    <textarea name='query' autofocus="autofocus" cols='50' rows='10'>{{ query }}</textarea>
   </div>
   <button type="submit" id="submit" class="btn btn-primary mt-4">Search</button>
 </form>


### PR DESCRIPTION
Add missing '>' to unhide the query search box on the initial CORD
search page.