### PR TITLE
Use different submission queues

### DIFF
--- a/config/webui-config.docker
+++ b/config/webui-config.docker
@@ -9,7 +9,10 @@ ORCID_AUTHORIZE_URL = 'http://localhost:8000/p/oauth/authorize'
 ORCID_ACCESS_TOKEN_URL = 'http://localhost:80/p/oauth/token'  # :80 since we run on port 80 in the container
 
 TODO_PATH = '/data-disk/reader-compute/reader-classic/queue/todo'
+TODO_PATH_CORD = '/data-disk/reader-compute/reader-classic/queue/todo'
+TODO_PATH_TRUST = '/data-disk/reader-compute/reader-classic/queue/todo'
 BACKLOG_PATH = '/data-disk/reader-compute/reader-classic/queue/backlog'
+BACKLOG_PATH_TRUST = '/data-disk/reader-compute/reader-classic/queue/backlog'
 SOLR_URL_GUTENBERG = 'http://localhost:7000/solr/reader-gutenberg'
 SOLR_URL_CORD = 'http://localhost:7000/solr/reader-cord'
 

--- a/webui/config.local
+++ b/webui/config.local
@@ -10,7 +10,10 @@ ORCID_AUTHORIZE_URL = 'http://localhost:5000/oauth/authorize'
 ORCID_ACCESS_TOKEN_URL = 'http://localhost:5000/oauth/token'
 
 TODO_PATH = 'queue/todo'
+TODO_PATH_CORD = 'queue/todo'
+TODO_PATH_TRUST = 'queue/todo'
 BACKLOG_PATH = 'queue/backlog'
+BACKLOG_PATH_TRUST = 'queue/backlog'
 SOLR_URL_GUTENBERG = 'http://localhost:7000/solr/reader-gutenberg'
 SOLR_URL_CORD = 'http://localhost:7000/solr/reader-cord'
 


### PR DESCRIPTION
There are three submission queues, switch between them depending on the
job being submitted. This was overlooked in the initial port from the
CGI scripts.

Currently CORD and Trust jobs each have their own queue and everything
else shares a third queue.