### PR TITLE
Revert the cord route to /cord

### DIFF
--- a/webui/templates/debug-oauth-authorize.html
+++ b/webui/templates/debug-oauth-authorize.html
@@ -7,9 +7,9 @@
 
     <div class="col-12 col-sm-6 offset-sm-3">
 
-      <h1 id="page-header maroon mb-4">Create New Account</h1>
+      <h1 id="page-header maroon mb-4">Debug Oauth Screen, Who do you want to be?</h1>
 
-      <form method="post my-5">
+      <form method="post">
 
         <div class="form-group">
           <label for="name">Name</label>
@@ -21,11 +21,11 @@
         </div>
         <div class="form-group">
           <label for="redirect">Redirect URL</label>
-          <input type="text" class="form-control disabled" name="redirect" id="redirect" value="{{ request.args['redirect_uri'] }}" disabled="disabled">
+          <input type="text" class="form-control" name="redirect" id="redirect" value="{{ request.args['redirect_uri'] }}">
         </div>
         <div class="form-group">
           <label for="state">State</label>
-          <input type="text" class="form-control disabled" name="state" id="state" value="{{ request.args['state'] }}" disabled="disabled">
+          <input type="text" class="form-control" name="state" id="state" value="{{ request.args['state'] }}">
         </div>
         <button type="submit" id="submit" class="btn btn-primary mt-4">Sign In</button>
       </form>

--- a/webui/templates/gutenberg-results.html
+++ b/webui/templates/gutenberg-results.html
@@ -11,8 +11,6 @@ The Distant Reader - Project Gutenberg to study carrel
 	<div class="row">
 		<div class="col-12">
 
-			<form action="" method="GET">
-
 				<form action="" method="GET">
 					<div class="form-group">
 						<label for="query">Query</label>

--- a/webui/views.py
+++ b/webui/views.py
@@ -522,8 +522,7 @@ def create_gutenberg():
         "gutenberg-queue.html", username=username, shortname=shortname
     )
 
-# Next line route was /cord -- should it be cord-create?
-@app.route("/cord-create")
+@app.route("/cord")
 def cord_search():
     FACETFIELD = [
         "facet_journal",


### PR DESCRIPTION
Fix some extra form labels and typos that kept the debugging sign in
page from working.