### PR TITLE
Make a page for browsing public carrels

### DIFF
--- a/config/cron.d/distant-reader
+++ b/config/cron.d/distant-reader
@@ -1,12 +1,14 @@
 #
-# Periodic job to scrape the private carrels into the patron database for the
-# web front-end
+# Periodic job to scrape the public and private carrels into the patron
+# database for the web front-end
 #
-# Since the app user does not have a home directory, running this as me.
-# This is not ideal.
+# Since the app user does not have a home directory, running this as
+# me (dbrower). This is not ideal.
 #
 MAILTO=dbrower
 PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin
 SHELL=/bin/bash
 
-*/5 * * * * dbrower /opt/reader/scan_private_carrels.sh /data-disk/www/html/library/patrons/
+*/5 * * * * dbrower /opt/reader/scan_carrels.sh /data-disk/www/html/library/patrons/
+# only run this every 15 minutes, and offset from the other script by 3 minutes
+3,18,33,48 * * * * dbrower /opt/reader/scan_carrels.sh /data-disk/www/html/library/carrels/ public

--- a/deploy/deploy-web.sh
+++ b/deploy/deploy-web.sh
@@ -27,6 +27,7 @@ install --compare --owner=root --group=root --mode=644 \
 
 # copy the python components
 rsync --checksum --recursive webui/ /opt/reader
+cp lib/scan_carrels.sh /opt/reader
 chown -R app:app /opt/reader
 # this needs to run as the app user
 cd /opt/reader && sudo -u app env \

--- a/webui/models.py
+++ b/webui/models.py
@@ -264,3 +264,51 @@ class StudyCarrel(object):
             )
             for record in records
         ]
+
+    @staticmethod
+    def ForPublic():
+        db = get_db()
+        records = db.execute(
+            """SELECT owner, shortname, fullpath, status, created, items, words, readability, bytes
+            FROM carrels
+            WHERE status = "public" """,
+        ).fetchall()
+        return [
+            StudyCarrel(
+                record[0],
+                record[1],
+                record[2],
+                record[3],
+                record[4],
+                record[5],
+                record[6],
+                record[7],
+                record[8],
+            )
+            for record in records
+        ]
+
+    @staticmethod
+    def FromPublicShortname(shortname):
+        db = get_db()
+        record = db.execute(
+            """SELECT owner, shortname, fullpath, status, created, items, words, readability, bytes
+            FROM carrels
+            WHERE status = "public" and shortname = ? """,
+            (shortname,),
+        ).fetchone()
+        if record is None:
+            return None
+        return StudyCarrel(
+            record[0],
+            record[1],
+            record[2],
+            record[3],
+            record[4],
+            record[5],
+            record[6],
+            record[7],
+            record[8],
+        )
+
+

--- a/webui/templates/carrel_filelist.html
+++ b/webui/templates/carrel_filelist.html
@@ -1,5 +1,10 @@
 {% extends "base.html" %}
 
+{#- This template  handles the file listings for both public and private
+carrels. Doing both makes the logic a little strange in places. -#}
+
+{% set is_public = carrel.status == "public" %}
+
 {% block title %}
 Study Carrel {{ carrel.shortname }}
 {% endblock %}
@@ -23,7 +28,11 @@ Study Carrel {{ carrel.shortname }}
     </thead>
     {% if parentdir != '' %}
     <tr>
-      {% set parent_url = url_for('patron_carrel', username=current_user.username, carrel=carrel.shortname, p=darentdir) %}
+      {%- if is_public %}
+        {% set parent_url = url_for('public_carrel', carrel=carrel.shortname, p=parentdir) %}
+      {% else %}
+        {% set parent_url = url_for('patron_carrel', username=current_user.username, carrel=carrel.shortname, p=parentdir) %}
+      {% endif -%}
       <td><a href="{{ parent_url }}"><i class="fas fa-lg fa-fw fa-arrow-circle-left"></i></a></td>
       <td><a href="{{ parent_url }}">Parent Directory</a></td>
       <td>&nbsp;</td>
@@ -33,7 +42,11 @@ Study Carrel {{ carrel.shortname }}
     {% endif %}
     {% for entry in listing %}
     <tr>
-      {% set entry_url = url_for("patron_carrel", username=current_user.username, carrel=carrel.shortname, p=entry.path) %}
+      {%- if is_public %}
+        {% set entry_url = url_for("public_carrel", carrel=carrel.shortname, p=entry.path) %}
+      {% else %}
+        {% set entry_url = url_for("patron_carrel", username=current_user.username, carrel=carrel.shortname, p=entry.path) %}
+      {% endif -%}
       <td><a href="{{ entry_url }}">
           {% if entry.directory %}
             <i class="fas fa-lg fa-fw fa-folder"></i>

--- a/webui/templates/carrel_list.html
+++ b/webui/templates/carrel_list.html
@@ -1,7 +1,14 @@
 {% extends "base.html" %}
 
+{#- This template handle both the public carrel list and the private
+carrel lists -#}
+
 {% block title %}
-Study Carrels for {{ current_user.username }}
+{% if is_public %}
+  Public Catalog
+{% else %}
+  Study Carrels for {{ current_user.username }}
+{% endif %}
 {% endblock %}
 
 {% block head_additional %}
@@ -13,11 +20,20 @@ Study Carrels for {{ current_user.username }}
 {% block body %}
 <div class="container">
 
-  {{ breadcrumb("Browse My Carrels") }}
+  {% if is_public %}
+    {{ breadcrumb("Catalog") }}
+  {% else %}
+    {{ breadcrumb("Browse My Carrels") }}
+  {% endif %}
+
 
     <div class="col-12">
 
-      <h1 id="page-header">Browse My Carrels</h1>
+      {% if is_public %}
+        <h1 id="page-header">Browse Public Carrels</h1>
+      {% else %}
+        <h1 id="page-header">Browse My Carrels</h1>
+      {% endif %}
       <p>Below, select column headings and/or enter words into the search box to sort and filter catalog items. Use the results to read, browse, or download carrels.</p>
 
     </div>
@@ -49,10 +65,15 @@ Study Carrels for {{ current_user.username }}
               <td class='text-center'>{{ entry.readability }}</td>
               <td class='text-center'>{{ entry.size_bytes | filesizeformat }}</td>
               <td class='text-center'>
-                <a href='{{ url_for("patron_carrel", username=current_user.username, carrel=entry.shortname) }}'>Browse</a>,
-                {% if entry.status != "queued" %}
-                <a href='{{ url_for("patron_carrel", username=current_user.username, carrel=entry.shortname, p="index.htm") }}'>Read</a>,
-                <a href='{{ url_for("patron_carrel", username=current_user.username, carrel=entry.shortname, p="study-carrel.zip") }}'>Download</a>
+                {% if is_public %}
+                  {% set entry_url = url_for("public_carrel", carrel=entry.shortname) %}
+                {% else %}
+                  {% set entry_url = url_for("patron_carrel", username=current_user.username, carrel=entry.shortname) %}
+                {% endif %}
+                <a href='{{ entry_url }}'>Browse</a>
+                {%- if entry.status != "queued" -%},
+                  <a href='{{ entry_url ~ "index.htm" }}'>Read</a>,
+                  <a href='{{ entry_url ~ "study-carrel.zip" }}'>Download</a>
                 {% endif %}
               </td>
             </tr>

--- a/webui/templates/navbar.html
+++ b/webui/templates/navbar.html
@@ -12,7 +12,7 @@
             Browse Carrels
           </a>
           <div class="dropdown-menu">
-            <a class="dropdown-item" href="https://library.distantreader.org/catalog">Browse Public Carrels</a>
+            <a class="dropdown-item" href="{{ url_for('public_carrel_list') }}">Browse Public Carrels</a>
             {% if current_user.is_authenticated %}
               <a class="dropdown-item" href="{{ url_for('patron_carrel_list', username=current_user.username) }}">Browse Your Carrels</a>
             {% endif %}


### PR DESCRIPTION
* Add a page listing all the public carrels
* Adapt the existing private carrel listing pages to also work with
  public carrels (public and private carrels have different route
  structures based on legacy)
* scrape public carrels as well as private ones
* only display private carrels on the "your carrels" page since public
  carrels are considered something different.
* Adjust navbar to point to the new public carrel page
* Harvest carrels more efficiently, no need to scan subdirectories of a
  carrel.