### PR TITLE
Add sorting to the file listing pages

### DIFF
--- a/webui/templates/carrel_filelist.html
+++ b/webui/templates/carrel_filelist.html
@@ -40,10 +40,10 @@ Study Carrel {{ carrel.shortname }}
     <thead class="thead-light">
       <tr>
         <th></th>
-        <th><a href="?C=N;O=D">Name</a></th>
-        <th><a href="?C=M;O=A">Last modified</a></th>
-        <th><a href="?C=S;O=A">Size</a></th>
-        <th><a href="?C=D;O=A">Description</a></th>
+        <th><a href="?sort={{ "ND" if sortorder == "NA" else "NA" }}">Name</a></th>
+        <th><a href="?sort={{ "MD" if sortorder == "MA" else "MA" }}">Last modified</a></th>
+        <th><a href="?sort={{ "SD" if sortorder == "SA" else "SA" }}">Size</a></th>
+        <th>Description</th>
       </tr>
     </thead>
     <tbody>


### PR DESCRIPTION
Sort the data on the server side since we want to keep "Parent
Directory" at the top of the column, and since we render sizes as human
readable, so the sort gets messed up trying to do it client side.