### PR TITLE
Use nonbreaking space for facet counts

### DIFF
--- a/webui/templates/cord-results.html
+++ b/webui/templates/cord-results.html
@@ -62,9 +62,9 @@ The Distant Reader - COVID-19 literature to study carrel
         {% if facets[facet_field] %}
             <h3>{{ title }}</h3>
             <p>
-            {% for term, count in facets[facet_field] -%}
-                <a href='{{ url_for(request.endpoint, query=(query + " AND " + query_field +':"'+ term +'"')) }}'>{{ term }}</a> ({{ count }})
-                {%- if not loop.last %};{% endif -%}
+            {% for term, count in facets[facet_field] %}
+                <a href='{{ url_for(request.endpoint, query=(query + " AND " + query_field +':"'+ term +'"')) }}'>{{ term }}</a>&nbsp;({{ count }})
+                {%- if not loop.last %};{% endif %}
             {%- endfor -%}
             </p>
         {% endif %}

--- a/webui/templates/gutenberg-results.html
+++ b/webui/templates/gutenberg-results.html
@@ -78,8 +78,8 @@ The Distant Reader - Project Gutenberg to study carrel
       <h3>{{ title }}</h3>
       <p>
       {% for term, count in facets[facet_field] %}
-        <a href='?query={{ query }} AND {{ query_field }}:"{{ term }}"'>{{ term }}</a> ({{ count }})
-      {%- if not loop.last %};{% endif -%}
+        <a href='?query={{ query }} AND {{ query_field }}:"{{ term }}"'>{{ term }}</a>&nbsp;({{ count }})
+      {%- if not loop.last %};{% endif %}
       {%- endfor -%}
       </p>
     {% endif %}


### PR DESCRIPTION
This should keep each facet count on the same line with the facet label.
Add space between each facet term so they _will_ line break if possible.