### PR TITLE
Use url_for for link

### DIFF
--- a/webui/templates/cord.html
+++ b/webui/templates/cord.html
@@ -10,7 +10,7 @@ The Distant Reader - COVID-19 literature to study carrel
   <h4>CORD-19<i class="mx-2 fad fa-angle-double-right"></i>Carrel</h4>
 <p>Use this page to search a collection of more than 500,000 journal articles on the topic of COVID-19. Once you have identified a subset of the articles you would like to read more closely, you can create a study carrel from the results.</p>
 <p>This page is populated with the content of a data set called <a href="https://www.semanticscholar.org/cord19">CORD-19</a>, a collection of scholarly scientific journal articles on the topic of COVID-19. The data set is updated on a regular basis, and we stive to keep the index up-to-date.</p>
- <p>Enter a word, a few words, or a few words surrounded by quote marks to begin. Stymied? <a href="https://distantreader.org/p/cord?query=*%3A*">Search for everything</a>, and use the resulting page to limit the query.</p>
+<p>Enter a word, a few words, or a few words surrounded by quote marks to begin. Stymied? <a href="{{ url_for("cord_search", query="*:*") }}">Search for everything</a>, and use the resulting page to limit the query.</p>
 <form method='GET'>
   <div class="form-group">
 	<input name="query" autofocus="autofocus" class="form-control" size="50" value='{{ query }}'>

--- a/webui/templates/gutenberg.html
+++ b/webui/templates/gutenberg.html
@@ -10,7 +10,7 @@ The Distant Reader - Project Gutenberg to study carrel
     <h4>Gutenberg<i class="mx-2 fad fa-angle-double-right"></i>Carrel</h4>
     <p>Use this page to: 1) search a subset (30,000 items) of the venerable <a href="https://www.gutenberg.org">Project Gutenberg</a>, 2) refine the results, and 3) create a study carrel from the list of found items.</p>
     <p>The content of Project Gutenberg is strong on English literature, American literature, and Western philosophy, but just about any word or phrase will return something. This is a quick an easy way to create carrels whose content represents the complete works of a given author or an introduction a given subject.</p>
-    <p>Enter a word, a few words, or a few words surrounded by quote marks to begin. Stymied? <a href="https://distantreader.org/p/gutenberg?query=*%3A*">Search for everything</a> and use the resulting page to limit your query.</p>
+    <p>Enter a word, a few words, or a few words surrounded by quote marks to begin. Stymied? <a href="{{ url_for("gutenberg", query="*:*") }}">Search for everything</a> and use the resulting page to limit your query.</p>
       <form method="GET">
         <div class="form-group">
           <label for="shortname">Query</label>

--- a/webui/templates/home.html
+++ b/webui/templates/home.html
@@ -42,7 +42,7 @@
         <h3 class="maroon mt-5 mb-4">Working with Carrels</h3>
 
         <ul class="list-group list-group-flush">
-          <li class="list-group-item pointer shadow-sm p-4 mb-3" data-url="https://library.distantreader.org/catalog">
+          <li class="list-group-item pointer shadow-sm p-4 mb-3" data-url="{{ url_for("public_carrel_list") }}">
             <div class="row">
               <div class="col-12 col-md-2">
                 <p class="text-center"><i class="fad fa-fw fa-3x fa-list-alt trench-blue"></i></p>


### PR DESCRIPTION
Hardcoding distantreader.org/p doesn't work for local envrionments and
will break once we promote /p/ to the root of the domain.