### PR TITLE
Only overview text on public carrel list

### DIFF
--- a/webui/templates/carrel_list.html
+++ b/webui/templates/carrel_list.html
@@ -30,13 +30,12 @@ carrel lists -#}
 
       {% if is_public %}
         <h1 id="page-header">Browse Public Carrels</h1>
+        <p>This is a curated collection of study carrels &mdash; a library.</p>
+        <p>The purpose of this page is three-fold: 1) to demonstrate the size and scope of content carrels can contain, and 2) to save the time of the student, researcher, or scholar because a carrel of interest may already exist, and 3) to inspire readers who want to create their own carrels.</p>
+        <p>As of this writing there are about 2,000 items in the collection. Use the features of this page to filter and sort the carrels by their various characteristics. Use the View, Files, and Download links to access the content of the carrels. Remember, study carrels are stand-alone, structured data sets. This means two things. First, downloaded study carrels have the <em>exact</em> same functionality as these carrels. Second, given the unique, one-word name of any study carrel, it is more than possible to programmatically interact with a carrel whether it be here in the library, on your desktop, or hosted on some other website. But unlike traditional libraries, you do not have to return any times once they have been checked out.</p>
       {% else %}
         <h1 id="page-header">Browse My Carrels</h1>
       {% endif %}
-      <p>This is a curated collection of study carrels -- a library.</p>
-      <p>The purpose of this page is three-fold: 1) to demonstrate the size and scope of content carrels can contain, and 2) to save the time of the student, researcher, or scholar because a carrel of interest may already exist, and 3) to inspire readers who want to create their own carrels.</p>
-      <p>As of this writing there are about 2,000 items in the collection. Use the features of this page to filter and sort the carrels by their various characteristics. Use the View, Files, and Download links to access the content of the carrels. Remember, study carrels are stand-alone, structured data sets. This means two things. First, downloaded study carrels have the <em>exact</em> same functionality as these carrels. Second, given the unique, one-word name of any study carrel, it is more than possible to programmatically interact with a carrel whether it be here in the library, on your desktop, or hosted on some other website. But unlike traditional libraries, you do not have to return any times once they have been checked out.</p>
-
     </div>
     <!-- col-12 -->
 


### PR DESCRIPTION
There is a four paragraph introduction to the carrel collection that
should only appear on the public carrel list. Move the html so it is not
displayed on the private carrel list page.