### PR TITLE
Make jumbotron image background white

### DIFF
--- a/webui/static/main.css
+++ b/webui/static/main.css
@@ -57,7 +57,7 @@ h4 {
 
 #jumbotron {
   box-sizing: border-box;
-  background-color: var(--nd-blue);
+  background-color: white;
   padding-bottom: 3rem;
   padding-top: .5rem;
   border-radius: 0;


### PR DESCRIPTION
Making it dark it a big difference that ties it in with the navbar. This
makes it more part of the page.