### PR TITLE
Remove library virtual host

### DIFF
--- a/config/httpd-le-ssl.conf
+++ b/config/httpd-le-ssl.conf
@@ -31,22 +31,6 @@
     SSLCertificateChainFile /etc/letsencrypt/live/distantreader.org/chain.pem
 </VirtualHost>
 <VirtualHost *:443>
-    DocumentRoot /data-disk/www/html/library
-    ServerName library.distantreader.org
-    ServerAdmin emorgan@nd.edu
-	DirectoryIndex index.html index.htm index.shtml index.cgi
-	<Directory "/data-disk/www/html/library">
-		Options All
-		Options +Includes
-	</Directory>
-  CustomLog /var/log/httpd/library-access.log combined
-  ErrorLog /var/log/httpd/library-error.log
-SSLCertificateFile /etc/letsencrypt/live/distantreader.org/cert.pem
-SSLCertificateKeyFile /etc/letsencrypt/live/distantreader.org/privkey.pem
-Include /etc/letsencrypt/options-ssl-apache.conf
-SSLCertificateChainFile /etc/letsencrypt/live/distantreader.org/chain.pem
-</VirtualHost>
-<VirtualHost *:443>
     DocumentRoot /data-disk/www/html/cord
     ServerName cord.distantreader.org
     ServerAdmin emorgan@nd.edu

--- a/config/httpd.conf
+++ b/config/httpd.conf
@@ -418,23 +418,6 @@ RewriteCond %{SERVER_NAME} =cord.distantreader.org
 RewriteRule ^ https://%{SERVER_NAME}%{REQUEST_URI} [END,NE,R=permanent]
 </VirtualHost>
 
-# the home of library.distantreader.org
-<VirtualHost *:80>
-    DocumentRoot /data-disk/www/html/library
-    ServerName library.distantreader.org
-    ServerAdmin emorgan@nd.edu
-	DirectoryIndex index.html index.htm index.shtml index.cgi
-	<Directory "/data-disk/www/html/library">
-		Options All
-		Options +Includes
-	</Directory>
-  CustomLog /var/log/httpd/library-access.log combined
-  ErrorLog /var/log/httpd/library-error.log
-RewriteEngine on
-RewriteCond %{SERVER_NAME} =library.distantreader.org
-RewriteRule ^ https://%{SERVER_NAME}%{REQUEST_URI} [END,NE,R=permanent]
-</VirtualHost>
-
 # Supplemental configuration
 #
 # Load config files in the "/etc/httpd/conf.d" directory, if any.


### PR DESCRIPTION
Since all carrels can be viewed using a distantreader.org URL, we don't
need the library.distantreader.org virtual host.