### PR TITLE
Remove back-to-top button

### DIFF
--- a/webui/static/main.css
+++ b/webui/static/main.css
@@ -235,28 +235,6 @@ label {
   font-weight: bolder;
 }
 
-/* Back to top button  --------------------------------------- */
-#back-to-top {
-  display: none;
-  position: fixed;
-  bottom: 50%;
-  right: 0;
-  z-index: 99;
-  border: none;
-  outline: none;
-  background-color: var(--bright-blue);
-  color: var(--white) !important;
-  padding: 8px 4px 10px 4px;
-  border-radius: 2px 0 0 2px;
-  font-size: 1rem;
-  cursor: pointer !important;
-}
-
-#back-to-top:hover {
-  background-color: var(--bright-blue);
-  color: var(--white);
-}
-
 /* Footer  ----------------------------------------------------------*/
 #footer {
   margin-top: 6rem;

--- a/webui/static/main.js
+++ b/webui/static/main.js
@@ -8,47 +8,6 @@ $(document).ready(function() {
     });
   }
 
-  // Scroll to top ---------------------------------------------------------------
-  window.onscroll = function() {
-
-    if (document.body.scrollTop > 80 || document.documentElement.scrollTop > 80) {
-      document.getElementById("back-to-top").style.display = "block";
-    } else {
-      document.getElementById("back-to-top").style.display = "none";
-    }
-  };
-
-  $('#back-to-top').on("click", function(event) {
-
-    if (
-      location.pathname.replace(/^\//, '') == this.pathname.replace(/^\//, '') &&
-      location.hostname == this.hostname
-    ) {
-      // Figure out element to scroll to
-      var target = $(this.hash);
-      target = target.length ? target : $('[name=' + this.hash.slice(1) + ']');
-      // Does a scroll target exist?
-      if (target.length) {
-        // Only prevent default if animation is actually gonna happen
-        event.preventDefault();
-        $('html, body').animate({
-          scrollTop: target.offset().top
-        }, 300, function() {
-          // Callback after animation
-          // Must change focus!
-          var $target = $(target);
-          $target.focus();
-          if ($target.is(":focus")) { // Checking if the target was focused
-            return false;
-          } else {
-            $target.attr('tabindex', '-1'); // Adding tabindex for elements not focusable
-            $target.focus(); // Set focus again
-          }
-        });
-      }
-    }
-  });
-
   // Link to elements with data-url attributes ------------------------------------------
   $(document).on("click", "[data-url]", function() {
     let url = $(this).data("url");

--- a/webui/templates/base.html
+++ b/webui/templates/base.html
@@ -100,8 +100,4 @@
   {% endblock %}
 
   {% include "footer.html" %}
-
-  <!-- Back to top button -->
-  <a role="button" id="back-to-top" class="btn scroll-link" href="#top"><i class="fad fa-fw fa-2x fa-angle-up" aria-hidden="true"></i></a>
-
 </body>


### PR DESCRIPTION
It only makes sense on mobile devices, and then it takes up screen space. And the carrel pages already don't have it.